### PR TITLE
Add Ollama embedding backend and make embedding settings configurable

### DIFF
--- a/config/env/embedding-service.env
+++ b/config/env/embedding-service.env
@@ -1,4 +1,8 @@
 # Safe local development defaults for embedding-service.
 
-EMBEDDING_MODEL_NAME=fake-embedding-model
+EMBEDDING_BACKEND=fake
+EMBEDDING_MODEL_NAME=embeddinggemma
 EMBEDDING_DIMENSION=8
+OLLAMA_URL=http://localhost:11434
+OLLAMA_EMBED_TIMEOUT_SECONDS=30
+OLLAMA_KEEP_ALIVE=5m

--- a/config/env/embedding-service.env.example
+++ b/config/env/embedding-service.env.example
@@ -1,4 +1,8 @@
 # Copy and override for embedding-service deployments.
 
-EMBEDDING_MODEL_NAME=fake-embedding-model
+EMBEDDING_BACKEND=fake
+EMBEDDING_MODEL_NAME=embeddinggemma
 EMBEDDING_DIMENSION=8
+OLLAMA_URL=http://localhost:11434
+OLLAMA_EMBED_TIMEOUT_SECONDS=30
+OLLAMA_KEEP_ALIVE=5m

--- a/embedding_service/README.md
+++ b/embedding_service/README.md
@@ -6,7 +6,10 @@ The `embedding-service` is a dedicated model-serving boundary for query and docu
 
 The service centralizes embedding model selection, model version, output dimensionality, batching behavior, and runtime placement. Both `api-service` and `ingestion-worker` call this service instead of loading embedding models in-process.
 
-The skeleton uses deterministic fake embeddings so service contracts and tests can be built before choosing a real model.
+The service supports two embedding backends:
+
+- `fake`: deterministic fake embeddings for tests and contract validation.
+- `ollama`: runtime embeddings via Ollama's `/api/embed` endpoint.
 
 ## API Contract
 
@@ -15,7 +18,7 @@ Implemented:
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/health` | Service health check |
-| `GET` | `/model-info` | Current embedding model name and dimensionality |
+| `GET` | `/model-info` | Current embedding backend, model name, and configured dimensionality |
 | `POST` | `/embed` | Embed one text input |
 | `POST` | `/embed/batch` | Embed a batch of text inputs |
 
@@ -34,15 +37,21 @@ Response:
 ```json
 {
   "embedding": [0.1, 0.2],
-  "model_name": "fake-embedding-model",
-  "dimension": 8
+  "model_name": "embeddinggemma",
+  "dimension": 2
 }
 ```
 
 ## Configuration
 
+- `EMBEDDING_BACKEND` (`fake` or `ollama`)
 - `EMBEDDING_MODEL_NAME`
 - `EMBEDDING_DIMENSION`
+- `OLLAMA_URL`
+- `OLLAMA_EMBED_TIMEOUT_SECONDS`
+- `OLLAMA_KEEP_ALIVE`
+
+The service does not auto-pull models. Ollama must already have the configured model available.
 
 ## Related ADR
 

--- a/embedding_service/main.py
+++ b/embedding_service/main.py
@@ -1,6 +1,10 @@
 import hashlib
+import json
+from dataclasses import dataclass
+from typing import Protocol
+from urllib import error, request
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from shared.config import get_settings
@@ -13,6 +17,7 @@ app = FastAPI(title="Personal RAG Embedding Service")
 
 
 class ModelInfoResponse(BaseModel):
+    backend: str
     model_name: str
     dimension: int
 
@@ -37,6 +42,86 @@ class BatchEmbedResponse(BaseModel):
     dimension: int
 
 
+class EmbeddingBackend(Protocol):
+    def embed(self, text: str) -> list[float]:
+        """Embed one string input and return a vector."""
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed a list of string inputs and return one vector per input."""
+
+
+@dataclass
+class FakeEmbeddingBackend:
+    dimension: int
+
+    def embed(self, text: str) -> list[float]:
+        return fake_embedding(text, self.dimension)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed(text) for text in texts]
+
+
+@dataclass
+class OllamaEmbeddingBackend:
+    url: str
+    model_name: str
+    timeout_seconds: int
+    keep_alive: str
+
+    def _request_embeddings(self, texts: list[str]) -> list[list[float]]:
+        payload = json.dumps(
+            {
+                "model": self.model_name,
+                "input": texts,
+                "keep_alive": self.keep_alive,
+            }
+        ).encode("utf-8")
+        req = request.Request(
+            url=f"{self.url.rstrip('/')}/api/embed",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8")
+            raise HTTPException(status_code=502, detail=f"Ollama HTTP error: {detail}") from exc
+        except error.URLError as exc:
+            raise HTTPException(status_code=502, detail=f"Ollama unavailable: {exc.reason}") from exc
+
+        embeddings = body.get("embeddings")
+        if not isinstance(embeddings, list):
+            raise HTTPException(status_code=502, detail="Invalid Ollama response: missing embeddings")
+
+        return embeddings
+
+    def embed(self, text: str) -> list[float]:
+        embeddings = self._request_embeddings([text])
+        return embeddings[0]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        embeddings = self._request_embeddings(texts)
+        if len(embeddings) != len(texts):
+            raise HTTPException(status_code=502, detail="Invalid Ollama response: wrong embedding count")
+        return embeddings
+
+
+def _make_embedding_backend() -> EmbeddingBackend:
+    settings = get_settings()
+    if settings.embedding_backend == "ollama":
+        return OllamaEmbeddingBackend(
+            url=settings.ollama_url,
+            model_name=settings.embedding_model_name,
+            timeout_seconds=settings.ollama_embed_timeout_seconds,
+            keep_alive=settings.ollama_keep_alive,
+        )
+
+    return FakeEmbeddingBackend(dimension=settings.embedding_dimension)
+
+
 def fake_embedding(text: str, dimension: int) -> list[float]:
     digest = hashlib.sha256(text.encode("utf-8")).digest()
     return [round(digest[index] / 255.0, 6) for index in range(dimension)]
@@ -51,6 +136,7 @@ def health() -> HealthResponse:
 def model_info() -> ModelInfoResponse:
     settings = get_settings()
     return ModelInfoResponse(
+        backend=settings.embedding_backend,
         model_name=settings.embedding_model_name,
         dimension=settings.embedding_dimension,
     )
@@ -59,18 +145,23 @@ def model_info() -> ModelInfoResponse:
 @app.post("/embed", response_model=EmbedResponse)
 def embed(request: EmbedRequest) -> EmbedResponse:
     settings = get_settings()
+    embedding = _make_embedding_backend().embed(request.text)
+
     return EmbedResponse(
-        embedding=fake_embedding(request.text, settings.embedding_dimension),
+        embedding=embedding,
         model_name=settings.embedding_model_name,
-        dimension=settings.embedding_dimension,
+        dimension=len(embedding),
     )
 
 
 @app.post("/embed/batch", response_model=BatchEmbedResponse)
 def embed_batch(request: BatchEmbedRequest) -> BatchEmbedResponse:
     settings = get_settings()
+    embeddings = _make_embedding_backend().embed_batch(request.texts)
+    dimension = len(embeddings[0]) if embeddings else 0
+
     return BatchEmbedResponse(
-        embeddings=[fake_embedding(text, settings.embedding_dimension) for text in request.texts],
+        embeddings=embeddings,
         model_name=settings.embedding_model_name,
-        dimension=settings.embedding_dimension,
+        dimension=dimension,
     )

--- a/embedding_service/main.py
+++ b/embedding_service/main.py
@@ -90,11 +90,15 @@ class OllamaEmbeddingBackend:
             detail = exc.read().decode("utf-8")
             raise HTTPException(status_code=502, detail=f"Ollama HTTP error: {detail}") from exc
         except error.URLError as exc:
-            raise HTTPException(status_code=502, detail=f"Ollama unavailable: {exc.reason}") from exc
+            raise HTTPException(
+                status_code=502, detail=f"Ollama unavailable: {exc.reason}"
+            ) from exc
 
         embeddings = body.get("embeddings")
         if not isinstance(embeddings, list):
-            raise HTTPException(status_code=502, detail="Invalid Ollama response: missing embeddings")
+            raise HTTPException(
+                status_code=502, detail="Invalid Ollama response: missing embeddings"
+            )
 
         return embeddings
 
@@ -105,7 +109,9 @@ class OllamaEmbeddingBackend:
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
         embeddings = self._request_embeddings(texts)
         if len(embeddings) != len(texts):
-            raise HTTPException(status_code=502, detail="Invalid Ollama response: wrong embedding count")
+            raise HTTPException(
+                status_code=502, detail="Invalid Ollama response: wrong embedding count"
+            )
         return embeddings
 
 

--- a/embedding_service/tests/unit/test_embedding_service.py
+++ b/embedding_service/tests/unit/test_embedding_service.py
@@ -1,4 +1,8 @@
+import json
+from urllib import request
+
 from embedding_service.testing.mocks import make_fake_embedding, make_test_client
+from shared.config import get_settings
 
 
 def test_fake_embedding_is_deterministic() -> None:
@@ -9,9 +13,13 @@ def test_fake_embedding_is_deterministic() -> None:
     assert len(first) == 8
 
 
-def test_embed_endpoint_returns_configured_shape() -> None:
-    client = make_test_client()
+def test_embed_endpoint_returns_configured_shape(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_BACKEND", "fake")
+    monkeypatch.setenv("EMBEDDING_DIMENSION", "8")
+    monkeypatch.setenv("EMBEDDING_MODEL_NAME", "fake-embedding-model")
+    get_settings.cache_clear()
 
+    client = make_test_client()
     response = client.post("/embed", json={"text": "hello"})
 
     assert response.status_code == 200
@@ -21,12 +29,78 @@ def test_embed_endpoint_returns_configured_shape() -> None:
     assert body["model_name"] == "fake-embedding-model"
 
 
-def test_batch_embed_endpoint_returns_one_vector_per_text() -> None:
-    client = make_test_client()
+def test_batch_embed_endpoint_returns_one_vector_per_text(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_BACKEND", "fake")
+    monkeypatch.setenv("EMBEDDING_DIMENSION", "8")
+    get_settings.cache_clear()
 
+    client = make_test_client()
     response = client.post("/embed/batch", json={"texts": ["one", "two"]})
 
     assert response.status_code == 200
     body = response.json()
     assert len(body["embeddings"]) == 2
     assert all(len(vector) == 8 for vector in body["embeddings"])
+
+
+def test_model_info_includes_backend(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_BACKEND", "ollama")
+    monkeypatch.setenv("EMBEDDING_MODEL_NAME", "embeddinggemma")
+    monkeypatch.setenv("EMBEDDING_DIMENSION", "768")
+    get_settings.cache_clear()
+
+    client = make_test_client()
+    response = client.get("/model-info")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["backend"] == "ollama"
+    assert body["model_name"] == "embeddinggemma"
+    assert body["dimension"] == 768
+
+
+def test_ollama_backend_embed_and_batch(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_BACKEND", "ollama")
+    monkeypatch.setenv("EMBEDDING_MODEL_NAME", "embeddinggemma")
+    monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434")
+    monkeypatch.setenv("OLLAMA_KEEP_ALIVE", "5m")
+    monkeypatch.setenv("OLLAMA_EMBED_TIMEOUT_SECONDS", "30")
+    get_settings.cache_clear()
+
+    client = make_test_client()
+
+    class FakeResponse:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req: request.Request, timeout: int):
+        assert req.full_url == "http://ollama:11434/api/embed"
+        assert timeout == 30
+        payload = json.loads(req.data.decode("utf-8"))
+        assert payload["model"] == "embeddinggemma"
+        assert payload["keep_alive"] == "5m"
+
+        texts = payload["input"]
+        vectors = [[float(index + 1)] * 3 for index, _ in enumerate(texts)]
+        return FakeResponse({"embeddings": vectors})
+
+    monkeypatch.setattr("embedding_service.main.request.urlopen", fake_urlopen)
+
+    single = client.post("/embed", json={"text": "hello"})
+    assert single.status_code == 200
+    assert single.json()["dimension"] == 3
+    assert single.json()["embedding"] == [1.0, 1.0, 1.0]
+
+    batch = client.post("/embed/batch", json={"texts": ["one", "two"]})
+    assert batch.status_code == 200
+    assert batch.json()["dimension"] == 3
+    assert batch.json()["embeddings"] == [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]

--- a/embedding_service/tests/unit/test_embedding_service.py
+++ b/embedding_service/tests/unit/test_embedding_service.py
@@ -1,4 +1,5 @@
 import json
+from typing import cast
 from urllib import request
 
 from embedding_service.testing.mocks import make_fake_embedding, make_test_client
@@ -85,7 +86,8 @@ def test_ollama_backend_embed_and_batch(monkeypatch) -> None:
     def fake_urlopen(req: request.Request, timeout: int):
         assert req.full_url == "http://ollama:11434/api/embed"
         assert timeout == 30
-        payload = json.loads(req.data.decode("utf-8"))
+        assert isinstance(req.data, bytes)
+        payload = json.loads(cast(bytes, req.data).decode("utf-8"))
         assert payload["model"] == "embeddinggemma"
         assert payload["keep_alive"] == "5m"
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -20,8 +20,11 @@ class AppSettings(BaseSettings):
     ollama_url: str = Field(default="http://localhost:11434", alias="OLLAMA_URL")
     watch_roots: str = Field(default="./watch", alias="WATCH_ROOTS")
     document_store_path: str = Field(default="./documents", alias="DOCUMENT_STORE_PATH")
-    embedding_model_name: str = Field(default="fake-embedding-model", alias="EMBEDDING_MODEL_NAME")
+    embedding_backend: str = Field(default="fake", alias="EMBEDDING_BACKEND")
+    embedding_model_name: str = Field(default="embeddinggemma", alias="EMBEDDING_MODEL_NAME")
     embedding_dimension: int = Field(default=8, alias="EMBEDDING_DIMENSION")
+    ollama_embed_timeout_seconds: int = Field(default=30, alias="OLLAMA_EMBED_TIMEOUT_SECONDS")
+    ollama_keep_alive: str = Field(default="5m", alias="OLLAMA_KEEP_ALIVE")
 
 
 @lru_cache

--- a/shared/tests/unit/test_config.py
+++ b/shared/tests/unit/test_config.py
@@ -5,15 +5,24 @@ def test_settings_defaults_are_usable() -> None:
     settings = AppSettings()
 
     assert settings.rag_api_key == "dev-token"
+    assert settings.embedding_backend == "fake"
     assert settings.embedding_dimension == 8
-    assert settings.embedding_model_name == "fake-embedding-model"
+    assert settings.embedding_model_name == "embeddinggemma"
+    assert settings.ollama_embed_timeout_seconds == 30
+    assert settings.ollama_keep_alive == "5m"
 
 
 def test_settings_read_aliases(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_BACKEND", "ollama")
     monkeypatch.setenv("EMBEDDING_DIMENSION", "16")
     monkeypatch.setenv("EMBEDDING_MODEL_NAME", "test-model")
+    monkeypatch.setenv("OLLAMA_EMBED_TIMEOUT_SECONDS", "60")
+    monkeypatch.setenv("OLLAMA_KEEP_ALIVE", "10m")
 
     settings = AppSettings()
 
+    assert settings.embedding_backend == "ollama"
     assert settings.embedding_dimension == 16
     assert settings.embedding_model_name == "test-model"
+    assert settings.ollama_embed_timeout_seconds == 60
+    assert settings.ollama_keep_alive == "10m"


### PR DESCRIPTION
### Motivation

- Enable runtime embedding via Ollama while keeping the deterministic fake backend for tests and local development.
- Make embedding-related configuration (backend, model, dimension, timeout, keep-alive) driven by environment settings.

### Description

- Introduces an `EmbeddingBackend` protocol and two implementations: `FakeEmbeddingBackend` and `OllamaEmbeddingBackend`, plus a factory ` _make_embedding_backend()` used by endpoints. 
- Replaces direct `fake_embedding` calls in `/embed` and `/embed/batch` with the selected backend and returns actual embedding vector lengths for `dimension` fields. 
- Adds new configuration fields to `AppSettings`: `embedding_backend`, `ollama_embed_timeout_seconds`, and `ollama_keep_alive`, and changes the default `EMBEDDING_MODEL_NAME` to `embeddinggemma`.
- Updates environment examples, `embedding_service/README.md` to document the `ollama` backend and new environment variables, and expands unit tests to cover backend selection, model-info backend field, and a mocked Ollama HTTP embed flow.

### Testing

- Ran unit tests in `embedding_service/tests/unit/test_embedding_service.py`, which exercise fake backend behavior, `/embed` and `/embed/batch` shapes, `GET /model-info`, and a mocked Ollama flow; all tests passed. 
- Ran unit tests in `shared/tests/unit/test_config.py` to validate default and alias-driven settings parsing, including new Ollama-related fields; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee527f884c832283fdb465abeea7e8)