### PR TITLE
Add Gemini PR-Agent workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,32 @@
+name: PR Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr_agent:
+    name: Run PR Agent
+    runs-on: ubuntu-latest
+    if: >
+      github.event.sender.type != 'Bot' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    steps:
+      - name: PR Agent
+        uses: the-pr-agent/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "false"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,18 @@
+[config]
+model = "gemini/gemini-1.5-flash"
+fallback_models = ["gemini/gemini-1.5-flash"]
+
+[pr_reviewer]
+require_tests_review = true
+require_score_review = false
+require_security_review = true
+require_estimate_effort_to_review = true
+num_code_suggestions = 4
+
+[pr_description]
+publish_labels = true
+add_original_user_description = true
+
+[pr_code_suggestions]
+num_code_suggestions = 4
+summarize = true


### PR DESCRIPTION
## Summary
- Add a PR-Agent GitHub Actions workflow powered by a `GEMINI_API_KEY` repository secret.
- Add PR-Agent TOML configuration for Gemini Flash review, description, and code suggestion behavior.
- Keep the workflow from running on fork-originated `pull_request` events while allowing same-repo PR testing.

## Validation
- `make test.smoke`
- `git diff --cached --check`
- `actionlint .github/workflows/pr-agent.yml` was skipped because `actionlint` is not installed in the local environment.

## Follow-up Setup
- Add the `GEMINI_API_KEY` repository secret before expecting PR-Agent to call Gemini successfully.
- After the first successful test, replace `the-pr-agent/pr-agent@main` with a pinned commit SHA.