### PR TITLE
[codex] Implement watch-root scanner

### DIFF
--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -6,11 +6,18 @@ The `ingestion-worker` owns background document processing.
 
 The worker claims ingestion jobs, scans configured watch roots, reconciles the index against the filesystem source of truth, parses supported files, chunks text, calls `embedding-service`, and writes metadata/vectors/document copies.
 
-The current implementation exposes the health endpoint plus parser and chunker building blocks. Job claiming, embedding calls, indexing, PostgreSQL writes, and managed document-copy writes are intentionally outside this module slice.
+The current implementation exposes the health endpoint plus filesystem scanning,
+managed-copy, parser, and chunker building blocks. Job claiming, embedding calls,
+indexing, and PostgreSQL writes are intentionally outside this module slice.
 
 ## Responsibilities
 
 - Dispatch supported source files through a parser registry.
+- Discover supported files under configured watch roots.
+- Skip hidden files and directories during scans by default.
+- Follow symlinks during scans with cycle protection.
+- Compute SHA-256 hashes from raw source bytes.
+- Copy originals into a hash-addressed managed document store.
 - Parse Markdown files (`.md`, `.markdown`) into normalized sections with heading paths.
 - Parse PDF files (`.pdf`) into normalized page/paragraph sections.
 - Detect PDFs with no extractable text layer by raising `EmptyScannedPdfError`.
@@ -27,6 +34,23 @@ Implemented:
 | `GET` | `/health` | Service health check |
 
 The worker is primarily job-driven through PostgreSQL-backed job records, not an external public API.
+
+## Filesystem Contract
+
+`ingestion_worker.filesystem` provides:
+
+- `parse_watch_roots()`: parses `WATCH_ROOTS` as an `os.pathsep`-separated
+  path list.
+- `scan_watch_roots()`: recursively discovers parser-supported files and
+  reports missing or unhealthy roots separately.
+- `compute_sha256()`: hashes raw source bytes.
+- `copy_to_managed_store()`: copies originals into
+  `<DOCUMENT_STORE_PATH>/<first-two-hash-chars>/<sha256><lowercase-suffix>`.
+
+Scans skip dot-prefixed files and directories by default. Symlinks are followed,
+and resolved directories/files are tracked so cycles and duplicate discoveries do
+not repeat work. Unhealthy roots are reported in the scan result; deletion
+reconciliation is intentionally out of scope for this module slice.
 
 ## Parser Contract
 
@@ -51,7 +75,7 @@ The chunker accepts a `ParsedDocument`, keeps chunks inside parser section bound
 - `POSTGRES_URL`
 - `QDRANT_URL`
 - `EMBEDDING_SERVICE_URL`
-- `WATCH_ROOTS`
+- `WATCH_ROOTS` (`os.pathsep`-separated when multiple roots are configured)
 - `DOCUMENT_STORE_PATH`
 
 ## Related ADRs

--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -52,6 +52,11 @@ and resolved directories/files are tracked so cycles and duplicate discoveries d
 not repeat work. Unhealthy roots are reported in the scan result; deletion
 reconciliation is intentionally out of scope for this module slice.
 
+Managed-copy hashes must be 64-character SHA-256 hex digests. Hash values are
+normalized to lowercase before path construction, existing managed copies are
+verified before reuse, and new copies are written through a temporary file before
+being atomically moved into place.
+
 ## Parser Contract
 
 `ingestion_worker.parsing` provides:

--- a/ingestion_worker/filesystem.py
+++ b/ingestion_worker/filesystem.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ingestion_worker.parsing import ParserRegistry, default_parser_registry
+
+
+@dataclass(frozen=True)
+class DiscoveredFile:
+    """Supported source file found under a configured watch root."""
+
+    source_path: Path
+    root_path: Path
+    relative_path: Path
+    suffix: str
+
+
+@dataclass(frozen=True)
+class UnhealthyWatchRoot:
+    """Watch root that could not be safely scanned."""
+
+    root_path: Path
+    reason: str
+
+
+@dataclass(frozen=True)
+class WatchScanResult:
+    """Result of scanning watch roots without applying deletion behavior."""
+
+    files: tuple[DiscoveredFile, ...]
+    unhealthy_roots: tuple[UnhealthyWatchRoot, ...]
+
+
+@dataclass(frozen=True)
+class ManagedCopy:
+    """Managed document-store copy of a source file."""
+
+    source_path: Path
+    managed_path: Path
+    content_hash: str
+    byte_size: int
+
+
+def parse_watch_roots(value: str) -> tuple[Path, ...]:
+    """Parse the WATCH_ROOTS environment value as an OS path list."""
+    return tuple(
+        Path(part.strip()).expanduser() for part in value.split(os.pathsep) if part.strip()
+    )
+
+
+def compute_sha256(path: Path) -> str:
+    """Compute a SHA-256 digest from raw file bytes."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for block in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def copy_to_managed_store(
+    source_path: Path,
+    content_hash: str,
+    document_store_path: Path,
+) -> ManagedCopy:
+    """Copy a source file into the managed store using a hash-derived path."""
+    source = Path(source_path)
+    destination = (
+        Path(document_store_path).expanduser()
+        / content_hash[:2]
+        / f"{content_hash}{source.suffix.lower()}"
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.exists():
+        if compute_sha256(destination) != content_hash:
+            raise ValueError(f"Managed copy hash mismatch: {destination}")
+    else:
+        shutil.copyfile(source, destination)
+
+    return ManagedCopy(
+        source_path=source,
+        managed_path=destination,
+        content_hash=content_hash,
+        byte_size=destination.stat().st_size,
+    )
+
+
+def scan_watch_roots(
+    roots: Iterable[Path],
+    parser_registry: ParserRegistry | None = None,
+    include_hidden: bool = False,
+) -> WatchScanResult:
+    """Discover supported files under healthy watch roots.
+
+    Missing or unreadable roots are reported separately so future deletion
+    reconciliation can avoid treating those roots as empty.
+    """
+    registry = parser_registry or default_parser_registry()
+    files: list[DiscoveredFile] = []
+    unhealthy_roots: list[UnhealthyWatchRoot] = []
+
+    for root in roots:
+        root_path = Path(root).expanduser()
+        if not root_path.exists():
+            unhealthy_roots.append(UnhealthyWatchRoot(root_path=root_path, reason="missing"))
+            continue
+        if not root_path.is_dir():
+            unhealthy_roots.append(UnhealthyWatchRoot(root_path=root_path, reason="not_directory"))
+            continue
+
+        try:
+            discovered = _scan_root(root_path, registry, include_hidden)
+        except OSError as exc:
+            unhealthy_roots.append(
+                UnhealthyWatchRoot(root_path=root_path, reason=f"unreadable: {exc}")
+            )
+            continue
+        files.extend(discovered)
+
+    return WatchScanResult(files=tuple(files), unhealthy_roots=tuple(unhealthy_roots))
+
+
+def _scan_root(
+    root_path: Path,
+    parser_registry: ParserRegistry,
+    include_hidden: bool,
+) -> list[DiscoveredFile]:
+    files: list[DiscoveredFile] = []
+    seen_dirs: set[Path] = set()
+    seen_files: set[Path] = set()
+
+    def visit(directory: Path) -> None:
+        resolved_directory = directory.resolve(strict=True)
+        if resolved_directory in seen_dirs:
+            return
+        seen_dirs.add(resolved_directory)
+
+        for child in sorted(directory.iterdir(), key=lambda path: path.name):
+            if not include_hidden and _has_hidden_part(child, root_path):
+                continue
+
+            if child.is_dir():
+                visit(child)
+                continue
+
+            if not child.is_file() or parser_registry.get_parser(child) is None:
+                continue
+
+            resolved_file = child.resolve(strict=True)
+            if resolved_file in seen_files:
+                continue
+            seen_files.add(resolved_file)
+
+            files.append(
+                DiscoveredFile(
+                    source_path=child,
+                    root_path=root_path,
+                    relative_path=child.relative_to(root_path),
+                    suffix=child.suffix.lower(),
+                )
+            )
+
+    visit(root_path)
+    return files
+
+
+def _has_hidden_part(path: Path, root_path: Path) -> bool:
+    relative_path = path.relative_to(root_path)
+    return any(part.startswith(".") for part in relative_path.parts)

--- a/ingestion_worker/filesystem.py
+++ b/ingestion_worker/filesystem.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import shutil
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,7 @@ class UnhealthyWatchRoot:
 
     root_path: Path
     reason: str
+    detail: str | None = None
 
 
 @dataclass(frozen=True)
@@ -68,24 +70,32 @@ def copy_to_managed_store(
     document_store_path: Path,
 ) -> ManagedCopy:
     """Copy a source file into the managed store using a hash-derived path."""
+    normalized_hash = _normalize_content_hash(content_hash)
     source = Path(source_path)
     destination = (
         Path(document_store_path).expanduser()
-        / content_hash[:2]
-        / f"{content_hash}{source.suffix.lower()}"
+        / normalized_hash[:2]
+        / f"{normalized_hash}{source.suffix.lower()}"
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     if destination.exists():
-        if compute_sha256(destination) != content_hash:
+        if compute_sha256(destination) != normalized_hash:
             raise ValueError(f"Managed copy hash mismatch: {destination}")
     else:
-        shutil.copyfile(source, destination)
+        temp_path = _copy_to_temporary_file(source, destination.parent)
+        try:
+            if compute_sha256(temp_path) != normalized_hash:
+                raise ValueError(f"Source content hash mismatch: {source}")
+            os.replace(temp_path, destination)
+        finally:
+            if temp_path.exists():
+                temp_path.unlink()
 
     return ManagedCopy(
         source_path=source,
         managed_path=destination,
-        content_hash=content_hash,
+        content_hash=normalized_hash,
         byte_size=destination.stat().st_size,
     )
 
@@ -117,7 +127,7 @@ def scan_watch_roots(
             discovered = _scan_root(root_path, registry, include_hidden)
         except OSError as exc:
             unhealthy_roots.append(
-                UnhealthyWatchRoot(root_path=root_path, reason=f"unreadable: {exc}")
+                UnhealthyWatchRoot(root_path=root_path, reason="unreadable", detail=str(exc))
             )
             continue
         files.extend(discovered)
@@ -172,3 +182,24 @@ def _scan_root(
 def _has_hidden_part(path: Path, root_path: Path) -> bool:
     relative_path = path.relative_to(root_path)
     return any(part.startswith(".") for part in relative_path.parts)
+
+
+def _normalize_content_hash(content_hash: str) -> str:
+    normalized = content_hash.lower()
+    if len(normalized) != 64 or any(
+        character not in "0123456789abcdef" for character in normalized
+    ):
+        raise ValueError("content_hash must be a 64-character SHA-256 hex digest")
+    return normalized
+
+
+def _copy_to_temporary_file(source: Path, destination_directory: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        dir=destination_directory,
+        prefix=".tmp-",
+        delete=False,
+    ) as temp_file:
+        temp_path = Path(temp_file.name)
+        with source.open("rb") as source_file:
+            shutil.copyfileobj(source_file, temp_file)
+    return temp_path

--- a/ingestion_worker/tests/unit/test_filesystem.py
+++ b/ingestion_worker/tests/unit/test_filesystem.py
@@ -140,3 +140,60 @@ def test_copy_to_managed_store_is_idempotent_for_identical_content(tmp_path: Pat
     second_copy = copy_to_managed_store(source, content_hash, document_store)
 
     assert second_copy == first_copy
+
+
+def test_copy_to_managed_store_normalizes_uppercase_hash(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_bytes(b"managed content")
+    content_hash = compute_sha256(source)
+    document_store = tmp_path / "documents"
+
+    managed_copy = copy_to_managed_store(source, content_hash.upper(), document_store)
+
+    assert managed_copy.content_hash == content_hash
+    assert managed_copy.managed_path == document_store / content_hash[:2] / f"{content_hash}.md"
+
+
+def test_copy_to_managed_store_rejects_invalid_hash(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_bytes(b"managed content")
+
+    try:
+        copy_to_managed_store(source, "../not-a-sha", tmp_path / "documents")
+    except ValueError as exc:
+        assert str(exc) == "content_hash must be a 64-character SHA-256 hex digest"
+    else:
+        raise AssertionError("expected invalid content hash to raise")
+
+
+def test_copy_to_managed_store_rejects_existing_mismatched_copy(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_bytes(b"managed content")
+    content_hash = compute_sha256(source)
+    document_store = tmp_path / "documents"
+    managed_path = document_store / content_hash[:2] / f"{content_hash}.md"
+    managed_path.parent.mkdir(parents=True)
+    managed_path.write_bytes(b"different content")
+
+    try:
+        copy_to_managed_store(source, content_hash, document_store)
+    except ValueError as exc:
+        assert str(exc) == f"Managed copy hash mismatch: {managed_path}"
+    else:
+        raise AssertionError("expected mismatched managed copy to raise")
+
+
+def test_copy_to_managed_store_rejects_source_hash_mismatch(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_bytes(b"managed content")
+    wrong_hash = compute_sha256(tmp_path / "source.md")
+    source.write_bytes(b"changed content")
+
+    try:
+        copy_to_managed_store(source, wrong_hash, tmp_path / "documents")
+    except ValueError as exc:
+        assert str(exc) == f"Source content hash mismatch: {source}"
+    else:
+        raise AssertionError("expected source hash mismatch to raise")
+
+    assert list((tmp_path / "documents" / wrong_hash[:2]).iterdir()) == []

--- a/ingestion_worker/tests/unit/test_filesystem.py
+++ b/ingestion_worker/tests/unit/test_filesystem.py
@@ -1,0 +1,142 @@
+import os
+from pathlib import Path
+
+from ingestion_worker.filesystem import (
+    compute_sha256,
+    copy_to_managed_store,
+    parse_watch_roots,
+    scan_watch_roots,
+)
+
+
+def test_parse_watch_roots_uses_os_pathsep_and_ignores_empty_segments() -> None:
+    roots = parse_watch_roots(f" /watch/one {os.pathsep}{os.pathsep}/watch/two{os.pathsep}   ")
+
+    assert roots == (Path("/watch/one"), Path("/watch/two"))
+
+
+def test_scan_watch_roots_returns_supported_files_recursively(tmp_path: Path) -> None:
+    watch_root = tmp_path / "watch"
+    nested = watch_root / "nested"
+    nested.mkdir(parents=True)
+    markdown = watch_root / "notes.md"
+    markdown.write_text("notes", encoding="utf-8")
+    pdf = nested / "paper.pdf"
+    pdf.write_bytes(b"%PDF placeholder")
+    unsupported = nested / "image.png"
+    unsupported.write_bytes(b"not a document")
+
+    result = scan_watch_roots((watch_root,))
+
+    assert result.unhealthy_roots == ()
+    assert [file.relative_path for file in result.files] == [
+        Path("nested/paper.pdf"),
+        Path("notes.md"),
+    ]
+    assert [file.suffix for file in result.files] == [".pdf", ".md"]
+
+
+def test_scan_watch_roots_skips_hidden_paths_by_default(tmp_path: Path) -> None:
+    watch_root = tmp_path / "watch"
+    hidden_dir = watch_root / ".hidden"
+    hidden_dir.mkdir(parents=True)
+    hidden_file = watch_root / ".secret.md"
+    hidden_file.write_text("secret", encoding="utf-8")
+    hidden_dir_file = hidden_dir / "nested.md"
+    hidden_dir_file.write_text("secret", encoding="utf-8")
+    visible = watch_root / "visible.md"
+    visible.write_text("visible", encoding="utf-8")
+
+    result = scan_watch_roots((watch_root,))
+
+    assert [file.relative_path for file in result.files] == [Path("visible.md")]
+
+
+def test_scan_watch_roots_can_include_hidden_paths(tmp_path: Path) -> None:
+    watch_root = tmp_path / "watch"
+    hidden_dir = watch_root / ".hidden"
+    hidden_dir.mkdir(parents=True)
+    (hidden_dir / "nested.md").write_text("secret", encoding="utf-8")
+    (watch_root / ".secret.md").write_text("secret", encoding="utf-8")
+    (watch_root / "visible.md").write_text("visible", encoding="utf-8")
+
+    result = scan_watch_roots((watch_root,), include_hidden=True)
+
+    assert [file.relative_path for file in result.files] == [
+        Path(".hidden/nested.md"),
+        Path(".secret.md"),
+        Path("visible.md"),
+    ]
+
+
+def test_scan_watch_roots_reports_unhealthy_roots_and_scans_healthy_roots(
+    tmp_path: Path,
+) -> None:
+    healthy_root = tmp_path / "watch"
+    healthy_root.mkdir()
+    (healthy_root / "notes.md").write_text("notes", encoding="utf-8")
+    missing_root = tmp_path / "missing"
+    file_root = tmp_path / "not-a-directory"
+    file_root.write_text("plain file", encoding="utf-8")
+
+    result = scan_watch_roots((missing_root, file_root, healthy_root))
+
+    assert [file.relative_path for file in result.files] == [Path("notes.md")]
+    assert [(root.root_path, root.reason) for root in result.unhealthy_roots] == [
+        (missing_root, "missing"),
+        (file_root, "not_directory"),
+    ]
+
+
+def test_scan_watch_roots_follows_symlinks_without_duplicates_or_cycles(
+    tmp_path: Path,
+) -> None:
+    watch_root = tmp_path / "watch"
+    real_dir = watch_root / "real"
+    real_dir.mkdir(parents=True)
+    (real_dir / "notes.md").write_text("notes", encoding="utf-8")
+    (watch_root / "linked-real").symlink_to(real_dir, target_is_directory=True)
+    (real_dir / "cycle").symlink_to(watch_root, target_is_directory=True)
+    (watch_root / "linked-notes.md").symlink_to(real_dir / "notes.md")
+
+    result = scan_watch_roots((watch_root,))
+
+    assert [file.relative_path for file in result.files] == [Path("linked-notes.md")]
+
+
+def test_compute_sha256_uses_raw_bytes(tmp_path: Path) -> None:
+    source = tmp_path / "document.md"
+    source.write_bytes(b"hello\nworld")
+
+    assert compute_sha256(source) == (
+        "26c60a61d01db5836ca70fefd44a6a016620413c8ef5f259a6c5612d4f79d3b8"
+    )
+
+
+def test_copy_to_managed_store_uses_hash_path_and_preserves_bytes(tmp_path: Path) -> None:
+    source = tmp_path / "source" / "Notes.MD"
+    source.parent.mkdir()
+    source.write_bytes(b"managed content")
+    content_hash = compute_sha256(source)
+    document_store = tmp_path / "documents"
+
+    managed_copy = copy_to_managed_store(source, content_hash, document_store)
+
+    expected_path = document_store / content_hash[:2] / f"{content_hash}.md"
+    assert managed_copy.source_path == source
+    assert managed_copy.managed_path == expected_path
+    assert managed_copy.content_hash == content_hash
+    assert managed_copy.byte_size == len(b"managed content")
+    assert expected_path.read_bytes() == b"managed content"
+
+
+def test_copy_to_managed_store_is_idempotent_for_identical_content(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_bytes(b"managed content")
+    content_hash = compute_sha256(source)
+    document_store = tmp_path / "documents"
+
+    first_copy = copy_to_managed_store(source, content_hash, document_store)
+    second_copy = copy_to_managed_store(source, content_hash, document_store)
+
+    assert second_copy == first_copy


### PR DESCRIPTION
### **User description**
## Summary

- Add filesystem helpers for parsing `WATCH_ROOTS`, scanning supported watch-root files, hashing raw source bytes, and copying originals into a hash-addressed managed document store.
- Report unhealthy roots separately so later deletion reconciliation can avoid unsafe behavior.
- Document the new ingestion worker filesystem contract.

Closes #7

## Validation

- `make lint`
- `make typecheck`
- `make test.unit`

Note: GitHub CLI is not installed in the devcontainer, so the PR was opened through the GitHub connector after pushing the branch.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Implements watch root scanning for supported files.

- Computes SHA-256 hashes for file content.

- Copies source files to a hash-addressed managed store.

- Reports unhealthy watch roots without deletion.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[WATCH_ROOTS environment variable] --> B{parse_watch_roots};
  B --> C{scan_watch_roots};
  C -- "Discovered Files" --> D[compute_sha256];
  D -- "Content Hash" --> E{copy_to_managed_store};
  E --> F[Managed Document Store];
  C -- "Unhealthy Roots" --> G[Report Unhealthy Roots];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filesystem.py</strong><dd><code>Implements watch root scanning and managed document store utilities.</code></dd></summary>
<hr>

ingestion_worker/filesystem.py

<ul><li>Introduces dataclasses for <code>DiscoveredFile</code>, <code>UnhealthyWatchRoot</code>, <br><code>WatchScanResult</code>, and <code>ManagedCopy</code>.<br> <li> Adds functions to parse <code>WATCH_ROOTS</code>, compute SHA-256 hashes, and copy <br>files to a managed store.<br> <li> Implements <code>scan_watch_roots</code> for recursive file discovery, handling <br>hidden paths, symlinks, and unhealthy roots.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/17/files#diff-fd2133b5b88de9fa2d19f65d457270e2df5859b873498bad49b5a64acdbcc782">+205/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_filesystem.py</strong><dd><code>Adds unit tests for filesystem scanning and managed copy functions.</code></dd></summary>
<hr>

ingestion_worker/tests/unit/test_filesystem.py

<ul><li>Adds comprehensive unit tests for <code>parse_watch_roots</code>, <code>scan_watch_roots</code>, <br><code>compute_sha256</code>, and <code>copy_to_managed_store</code>.<br> <li> Tests cover parsing multiple roots, recursive scanning, <br>skipping/including hidden files, handling unhealthy roots, symlink <br>following, hash computation, and managed copy idempotency and error <br>handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/17/files#diff-bf4fe9beff7ca653f4cd17ed5c0231c065599e9937dee48d1c6923c73d8022fd">+199/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updates documentation for new filesystem scanning and managed copy </code><br><code>features.</code></dd></summary>
<hr>

ingestion_worker/README.md

<ul><li>Updates the <code>ingestion-worker</code> summary and responsibilities to include <br>filesystem scanning and managed copy features.<br> <li> Adds a new "Filesystem Contract" section detailing the new functions <br>and their behavior.<br> <li> Clarifies the <code>WATCH_ROOTS</code> environment variable description.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/17/files#diff-a885046f76b95c2ffc2ff27bee22a4e0094da0c45ced0b97726425f13ccac8e2">+31/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

