### PR TITLE
Increase custom model token limit to 256000 in .pr_agent.toml

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [config]
 model = "gemini/gemini-3-flash"
 fallback_models = ["gemini/gemini-3-flash"]
+custom_model_max_tokens = 256000
 
 [pr_reviewer]
 require_tests_review = true


### PR DESCRIPTION
### Motivation
- Expose a higher token capacity for the configured LLM to support larger contexts and RAG use cases by increasing the custom model token limit.

### Description
- Add `custom_model_max_tokens = 256000` to the `[config]` section of `.pr_agent.toml`.

### Testing
- No automated tests were required or executed for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0439464dc8322beef1daf0636e18a)