### PR TITLE
revert to gemini 2.5

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,6 @@
 [config]
-model = "gemini/gemini-3-flash"
-fallback_models = ["gemini/gemini-3-flash"]
-custom_model_max_tokens = 256000
+model = "gemini/gemini-2.5-flash"
+fallback_models = ["gemini/gemini-2.5-flash"]
 
 [pr_reviewer]
 require_tests_review = true


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Reverted AI model to `gemini-2.5-flash`.

- Removed `custom_model_max_tokens` setting.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Reverted PR Agent configuration to Gemini 2.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Reverted the <code>model</code> configuration from <code>gemini/gemini-3-flash</code> to <br><code>gemini/gemini-2.5-flash</code>.<br> <li> Updated <code>fallback_models</code> to also use <code>gemini/gemini-2.5-flash</code>.<br> <li> Removed the <code>custom_model_max_tokens</code> setting.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/21/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

