### PR TITLE
[codex] Implement ingestion worker pipeline

### DIFF
--- a/docs/modules/ingestion-worker.md
+++ b/docs/modules/ingestion-worker.md
@@ -7,3 +7,5 @@
 ::: ingestion_worker.parsing
 
 ::: ingestion_worker.chunking
+
+::: ingestion_worker.pipeline

--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -47,6 +47,8 @@ The worker is primarily job-driven through PostgreSQL-backed job records, not an
 - `process_next_job()`: claims and processes the oldest pending ingestion job,
   returning `True` when a job was claimed and `False` when no pending job exists.
 - `process_pending_jobs_once()`: one-shot wrapper for manual runs and tests.
+- `run_next_job()` and `run_pending_job_once()`: structured-result variants
+  used by automation and the CLI.
 - `HttpEmbeddingClient`: minimal client for `GET /model-info` and
   `POST /embed/batch` on `embedding-service`.
 
@@ -57,7 +59,9 @@ python -m ingestion_worker.worker
 ```
 
 Each invocation processes at most one job and exits. It does not start a polling
-loop or scheduler.
+loop or scheduler. Pass `--fail-on-error` when automation should receive a
+non-zero exit code for a claimed job that ends in `failed`; an idle run with no
+pending job still exits successfully.
 
 Job status progresses through the persisted ADR-005 lifecycle states. A document
 version is marked active only after Qdrant upsert succeeds. Hard failures mark

--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -6,9 +6,8 @@ The `ingestion-worker` owns background document processing.
 
 The worker claims ingestion jobs, scans configured watch roots, reconciles the index against the filesystem source of truth, parses supported files, chunks text, calls `embedding-service`, and writes metadata/vectors/document copies.
 
-The current implementation exposes the health endpoint plus filesystem scanning,
-managed-copy, parser, and chunker building blocks. Job claiming, embedding calls,
-indexing, and PostgreSQL writes are intentionally outside this module slice.
+The current implementation exposes the health endpoint plus a one-shot worker
+pipeline for processing pending PostgreSQL ingestion jobs.
 
 ## Responsibilities
 
@@ -24,6 +23,12 @@ indexing, and PostgreSQL writes are intentionally outside this module slice.
 - Skip unsupported file formats gracefully by returning `None` from the registry.
 - Chunk parsed sections without crossing parser-provided structure boundaries.
 - Preserve citation metadata on chunks: source path, filename, Markdown heading path, PDF page number, section title, and character offsets where available.
+- Claim pending ingestion jobs with PostgreSQL row locking.
+- Process full-scan and single-path ingestion jobs once per worker invocation.
+- Call `embedding-service` for batch document embeddings.
+- Persist documents, versions, chunks, job state, and embedding metadata in PostgreSQL.
+- Upsert chunk vectors into Qdrant after chunk metadata is persisted.
+- Skip duplicate raw-byte content hashes without creating another document version.
 
 ## API Contract
 
@@ -34,6 +39,30 @@ Implemented:
 | `GET` | `/health` | Service health check |
 
 The worker is primarily job-driven through PostgreSQL-backed job records, not an external public API.
+
+## Worker Pipeline Contract
+
+`ingestion_worker.pipeline` provides:
+
+- `process_next_job()`: claims and processes the oldest pending ingestion job,
+  returning `True` when a job was claimed and `False` when no pending job exists.
+- `process_pending_jobs_once()`: one-shot wrapper for manual runs and tests.
+- `HttpEmbeddingClient`: minimal client for `GET /model-info` and
+  `POST /embed/batch` on `embedding-service`.
+
+The CLI entrypoint is:
+
+```bash
+python -m ingestion_worker.worker
+```
+
+Each invocation processes at most one job and exits. It does not start a polling
+loop or scheduler.
+
+Job status progresses through the persisted ADR-005 lifecycle states. A document
+version is marked active only after Qdrant upsert succeeds. Hard failures mark
+the job failed with an error message and mark any in-progress document/version
+failed for inspection.
 
 ## Filesystem Contract
 

--- a/ingestion_worker/pipeline.py
+++ b/ingestion_worker/pipeline.py
@@ -44,6 +44,42 @@ class BatchEmbeddingResult:
     dimension: int
 
 
+@dataclass(frozen=True)
+class IngestionRunResult:
+    """Structured outcome for one worker invocation."""
+
+    claimed: bool
+    status: str
+    job_id: str | None = None
+    processed_items: int = 0
+    error_message: str | None = None
+
+
+@dataclass
+class IngestionJobContext:
+    """Per-job cache for stable service metadata and index setup."""
+
+    embedding_client: EmbeddingClient
+    vector_index: VectorIndex
+    model_info: EmbeddingModelInfo | None = None
+    ensured_dimensions: set[int] | None = None
+
+    def get_model_info(self) -> EmbeddingModelInfo:
+        """Fetch embedding model info at most once for a claimed job."""
+        if self.model_info is None:
+            self.model_info = self.embedding_client.model_info()
+        return self.model_info
+
+    def ensure_collection(self, dimension: int) -> None:
+        """Ensure the vector collection once for each dimension in this job."""
+        if self.ensured_dimensions is None:
+            self.ensured_dimensions = set()
+        if dimension in self.ensured_dimensions:
+            return
+        self.vector_index.ensure_collection(dimension)
+        self.ensured_dimensions.add(dimension)
+
+
 class EmbeddingClient(Protocol):
     def model_info(self) -> EmbeddingModelInfo:
         """Return the currently configured embedding model identity."""
@@ -124,6 +160,11 @@ def process_pending_jobs_once(worker_id: str | None = None) -> bool:
     return process_next_job(worker_id=worker_id)
 
 
+def run_pending_job_once(worker_id: str | None = None) -> IngestionRunResult:
+    """Process at most one pending ingestion job and return its outcome."""
+    return run_next_job(worker_id=worker_id)
+
+
 def process_next_job(
     worker_id: str | None = None,
     settings: AppSettings | None = None,
@@ -134,12 +175,36 @@ def process_next_job(
     chunker: StructureAwareChunker | None = None,
 ) -> bool:
     """Claim and process the oldest pending ingestion job, if one exists."""
+    return run_next_job(
+        worker_id=worker_id,
+        settings=settings,
+        engine=engine,
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+        parser_registry=parser_registry,
+        chunker=chunker,
+    ).claimed
+
+
+def run_next_job(
+    worker_id: str | None = None,
+    settings: AppSettings | None = None,
+    engine: Engine | None = None,
+    embedding_client: EmbeddingClient | None = None,
+    vector_index: VectorIndex | None = None,
+    parser_registry: ParserRegistry | None = None,
+    chunker: StructureAwareChunker | None = None,
+) -> IngestionRunResult:
+    """Claim and process the oldest pending ingestion job, returning its outcome."""
     resolved_settings = settings or get_settings()
     resolved_engine = engine or create_metadata_engine(resolved_settings.postgres_url)
     resolved_embedding_client = embedding_client or HttpEmbeddingClient(
         resolved_settings.embedding_service_url
     )
-    resolved_vector_index = vector_index or QdrantVectorIndex()
+    resolved_vector_index = vector_index or QdrantVectorIndex(
+        url=resolved_settings.qdrant_url,
+        collection_name=resolved_settings.qdrant_collection,
+    )
     resolved_parser_registry = parser_registry or default_parser_registry()
     resolved_chunker = chunker or StructureAwareChunker()
     resolved_worker_id = worker_id or _default_worker_id()
@@ -148,32 +213,46 @@ def process_next_job(
         repository = MetadataRepository(connection)
         job = repository.claim_next_ingestion_job(resolved_worker_id)
         if job is None:
-            return False
+            return IngestionRunResult(claimed=False, status="idle")
 
         try:
             processed_items = _process_claimed_job(
                 repository=repository,
                 job=job,
                 settings=resolved_settings,
-                embedding_client=resolved_embedding_client,
-                vector_index=resolved_vector_index,
+                context=IngestionJobContext(
+                    embedding_client=resolved_embedding_client,
+                    vector_index=resolved_vector_index,
+                ),
                 parser_registry=resolved_parser_registry,
                 chunker=resolved_chunker,
             )
         except Exception as exc:
-            _mark_job_failed(repository, job["id"], str(exc))
+            failed_job = _mark_job_failed(repository, str(job["id"]), str(exc))
+            return IngestionRunResult(
+                claimed=True,
+                status="failed",
+                job_id=str(job["id"]),
+                processed_items=_required_int(failed_job, "processed_items"),
+                error_message=str(failed_job["error_message"]),
+            )
         else:
-            repository.update_ingestion_job(job["id"], "active", processed_items)
+            completed_job = repository.update_ingestion_job(job["id"], "active", processed_items)
+            return IngestionRunResult(
+                claimed=True,
+                status="active",
+                job_id=str(completed_job["id"]),
+                processed_items=int(completed_job["processed_items"]),
+            )
 
-    return True
+    raise RuntimeError("unreachable")
 
 
 def _process_claimed_job(
     repository: MetadataRepository,
     job: dict[str, object],
     settings: AppSettings,
-    embedding_client: EmbeddingClient,
-    vector_index: VectorIndex,
+    context: IngestionJobContext,
     parser_registry: ParserRegistry,
     chunker: StructureAwareChunker,
 ) -> int:
@@ -185,8 +264,7 @@ def _process_claimed_job(
             job_id=str(job["id"]),
             source_path=source_path,
             settings=settings,
-            embedding_client=embedding_client,
-            vector_index=vector_index,
+            context=context,
             parser_registry=parser_registry,
             chunker=chunker,
         )
@@ -228,8 +306,7 @@ def _process_source_path(
     job_id: str,
     source_path: Path,
     settings: AppSettings,
-    embedding_client: EmbeddingClient,
-    vector_index: VectorIndex,
+    context: IngestionJobContext,
     parser_registry: ParserRegistry,
     chunker: StructureAwareChunker,
 ) -> None:
@@ -270,8 +347,8 @@ def _process_source_path(
         repository.update_document_version_state(document_version_id, "chunked")
         repository.update_ingestion_job(job_id, "chunked")
 
-        model_info = embedding_client.model_info()
-        embedding_result = embedding_client.embed_batch([chunk.text for chunk in chunks])
+        model_info = context.get_model_info()
+        embedding_result = context.embedding_client.embed_batch([chunk.text for chunk in chunks])
         if embedding_result.dimension != model_info.dimension:
             raise IngestionPipelineError(
                 "Embedding service model-info dimension does not match batch response."
@@ -289,8 +366,8 @@ def _process_source_path(
             document_version_id,
             [_chunk_record(chunk) for chunk in chunks],
         )
-        vector_index.ensure_collection(embedding_result.dimension)
-        vector_index.upsert_chunks(
+        context.ensure_collection(embedding_result.dimension)
+        context.vector_index.upsert_chunks(
             [
                 ChunkVector(
                     chunk_id=str(chunk_record["id"]),
@@ -335,8 +412,12 @@ def _chunk_record(chunk: DocumentChunk) -> ChunkRecord:
     )
 
 
-def _mark_job_failed(repository: MetadataRepository, job_id: str, message: str) -> None:
-    repository.update_ingestion_job(job_id, "failed", error_message=message)
+def _mark_job_failed(
+    repository: MetadataRepository,
+    job_id: str,
+    message: str,
+) -> dict[str, object]:
+    return repository.update_ingestion_job(job_id, "failed", error_message=message)
 
 
 def _required_str(body: dict[str, object], key: str) -> str:

--- a/ingestion_worker/pipeline.py
+++ b/ingestion_worker/pipeline.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib import error, request
+from uuid import uuid4
+
+from sqlalchemy.engine import Engine
+
+from ingestion_worker.chunking import DocumentChunk, StructureAwareChunker
+from ingestion_worker.filesystem import (
+    compute_sha256,
+    copy_to_managed_store,
+    parse_watch_roots,
+    scan_watch_roots,
+)
+from ingestion_worker.parsing import ParserRegistry, default_parser_registry
+from shared.config import AppSettings, get_settings
+from shared.repository import ChunkRecord, MetadataRepository, create_metadata_engine
+from shared.vector_index import ChunkVector, QdrantVectorIndex
+
+
+class IngestionPipelineError(RuntimeError):
+    """Raised when a claimed ingestion job cannot be completed."""
+
+
+@dataclass(frozen=True)
+class EmbeddingModelInfo:
+    """Embedding model identity returned by `embedding-service`."""
+
+    model_name: str
+    dimension: int
+
+
+@dataclass(frozen=True)
+class BatchEmbeddingResult:
+    """Batch embedding response used by the ingestion pipeline."""
+
+    embeddings: list[list[float]]
+    model_name: str
+    dimension: int
+
+
+class EmbeddingClient(Protocol):
+    def model_info(self) -> EmbeddingModelInfo:
+        """Return the currently configured embedding model identity."""
+
+    def embed_batch(self, texts: list[str]) -> BatchEmbeddingResult:
+        """Embed one or more chunk texts."""
+
+
+class VectorIndex(Protocol):
+    def ensure_collection(self, dimension: int) -> None:
+        """Create or verify the vector collection for the embedding dimension."""
+
+    def upsert_chunks(self, chunks: list[ChunkVector]) -> None:
+        """Persist chunk vectors to the vector index."""
+
+
+class HttpEmbeddingClient:
+    """Small HTTP client for the embedding-service API."""
+
+    def __init__(self, base_url: str, timeout_seconds: int = 30) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def model_info(self) -> EmbeddingModelInfo:
+        """Fetch model identity from `GET /model-info`."""
+        body = self._request("GET", "/model-info")
+        return EmbeddingModelInfo(
+            model_name=_required_str(body, "model_name"),
+            dimension=_required_int(body, "dimension"),
+        )
+
+    def embed_batch(self, texts: list[str]) -> BatchEmbeddingResult:
+        """Embed chunk text through `POST /embed/batch`."""
+        body = self._request("POST", "/embed/batch", {"texts": texts})
+        embeddings = body.get("embeddings")
+        if not isinstance(embeddings, list) or not all(
+            isinstance(vector, list) for vector in embeddings
+        ):
+            raise IngestionPipelineError("Embedding service returned invalid embeddings.")
+        if len(embeddings) != len(texts):
+            raise IngestionPipelineError("Embedding service returned the wrong embedding count.")
+
+        return BatchEmbeddingResult(
+            embeddings=[[float(value) for value in vector] for vector in embeddings],
+            model_name=_required_str(body, "model_name"),
+            dimension=_required_int(body, "dimension"),
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        req = request.Request(
+            url=f"{self.base_url}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method=method,
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8")
+            raise IngestionPipelineError(f"Embedding service HTTP error: {detail}") from exc
+        except error.URLError as exc:
+            raise IngestionPipelineError(f"Embedding service unavailable: {exc.reason}") from exc
+
+        if not isinstance(body, dict):
+            raise IngestionPipelineError("Embedding service returned a non-object response.")
+        return body
+
+
+def process_pending_jobs_once(worker_id: str | None = None) -> bool:
+    """Process at most one pending ingestion job."""
+    return process_next_job(worker_id=worker_id)
+
+
+def process_next_job(
+    worker_id: str | None = None,
+    settings: AppSettings | None = None,
+    engine: Engine | None = None,
+    embedding_client: EmbeddingClient | None = None,
+    vector_index: VectorIndex | None = None,
+    parser_registry: ParserRegistry | None = None,
+    chunker: StructureAwareChunker | None = None,
+) -> bool:
+    """Claim and process the oldest pending ingestion job, if one exists."""
+    resolved_settings = settings or get_settings()
+    resolved_engine = engine or create_metadata_engine(resolved_settings.postgres_url)
+    resolved_embedding_client = embedding_client or HttpEmbeddingClient(
+        resolved_settings.embedding_service_url
+    )
+    resolved_vector_index = vector_index or QdrantVectorIndex()
+    resolved_parser_registry = parser_registry or default_parser_registry()
+    resolved_chunker = chunker or StructureAwareChunker()
+    resolved_worker_id = worker_id or _default_worker_id()
+
+    with resolved_engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        job = repository.claim_next_ingestion_job(resolved_worker_id)
+        if job is None:
+            return False
+
+        try:
+            processed_items = _process_claimed_job(
+                repository=repository,
+                job=job,
+                settings=resolved_settings,
+                embedding_client=resolved_embedding_client,
+                vector_index=resolved_vector_index,
+                parser_registry=resolved_parser_registry,
+                chunker=resolved_chunker,
+            )
+        except Exception as exc:
+            _mark_job_failed(repository, job["id"], str(exc))
+        else:
+            repository.update_ingestion_job(job["id"], "active", processed_items)
+
+    return True
+
+
+def _process_claimed_job(
+    repository: MetadataRepository,
+    job: dict[str, object],
+    settings: AppSettings,
+    embedding_client: EmbeddingClient,
+    vector_index: VectorIndex,
+    parser_registry: ParserRegistry,
+    chunker: StructureAwareChunker,
+) -> int:
+    source_paths = _resolve_job_source_paths(job, settings, parser_registry)
+    processed_items = 0
+    for source_path in source_paths:
+        _process_source_path(
+            repository=repository,
+            job_id=str(job["id"]),
+            source_path=source_path,
+            settings=settings,
+            embedding_client=embedding_client,
+            vector_index=vector_index,
+            parser_registry=parser_registry,
+            chunker=chunker,
+        )
+        processed_items += 1
+        repository.update_ingestion_job(str(job["id"]), "running", processed_items)
+    return processed_items
+
+
+def _resolve_job_source_paths(
+    job: dict[str, object],
+    settings: AppSettings,
+    parser_registry: ParserRegistry,
+) -> list[Path]:
+    requested_path = job.get("requested_path")
+    if requested_path:
+        return [_validate_requested_path(Path(str(requested_path)).expanduser(), parser_registry)]
+
+    scan_result = scan_watch_roots(parse_watch_roots(settings.watch_roots), parser_registry)
+    if scan_result.unhealthy_roots:
+        unhealthy = scan_result.unhealthy_roots[0]
+        raise IngestionPipelineError(
+            f"Unhealthy watch root {unhealthy.root_path}: {unhealthy.reason}"
+        )
+    return [discovered.source_path for discovered in scan_result.files]
+
+
+def _validate_requested_path(source_path: Path, parser_registry: ParserRegistry) -> Path:
+    if not source_path.exists():
+        raise IngestionPipelineError(f"Requested path does not exist: {source_path}")
+    if not source_path.is_file():
+        raise IngestionPipelineError(f"Requested path is not a file: {source_path}")
+    if parser_registry.get_parser(source_path) is None:
+        raise IngestionPipelineError(f"Unsupported document format: {source_path}")
+    return source_path
+
+
+def _process_source_path(
+    repository: MetadataRepository,
+    job_id: str,
+    source_path: Path,
+    settings: AppSettings,
+    embedding_client: EmbeddingClient,
+    vector_index: VectorIndex,
+    parser_registry: ParserRegistry,
+    chunker: StructureAwareChunker,
+) -> None:
+    content_hash = compute_sha256(source_path)
+    if repository.find_document_version_by_hash(content_hash) is not None:
+        return
+
+    document_version_id: str | None = None
+    document_id: str | None = None
+    try:
+        document = repository.get_or_create_document(str(source_path))
+        document_id = str(document["id"])
+        repository.update_document_state(document_id, "running")
+
+        managed_copy = copy_to_managed_store(
+            source_path,
+            content_hash,
+            Path(settings.document_store_path),
+        )
+        version = repository.create_document_version(
+            document_id,
+            content_hash,
+            str(managed_copy.managed_path),
+        )
+        document_version_id = str(version["id"])
+        repository.update_document_version_state(document_version_id, "copied")
+        repository.update_ingestion_job(job_id, "copied")
+
+        parsed_document = parser_registry.parse(source_path)
+        if parsed_document is None:
+            raise IngestionPipelineError(f"Unsupported document format: {source_path}")
+        repository.update_document_version_state(document_version_id, "parsed")
+        repository.update_ingestion_job(job_id, "parsed")
+
+        chunks = chunker.chunk(parsed_document)
+        if not chunks:
+            raise IngestionPipelineError(f"No chunkable text found: {source_path}")
+        repository.update_document_version_state(document_version_id, "chunked")
+        repository.update_ingestion_job(job_id, "chunked")
+
+        model_info = embedding_client.model_info()
+        embedding_result = embedding_client.embed_batch([chunk.text for chunk in chunks])
+        if embedding_result.dimension != model_info.dimension:
+            raise IngestionPipelineError(
+                "Embedding service model-info dimension does not match batch response."
+            )
+        repository.update_document_version_state(
+            document_version_id,
+            "embedded",
+            embedding_model_name=embedding_result.model_name,
+            embedding_dimension=embedding_result.dimension,
+        )
+        repository.update_ingestion_job(job_id, "embedded")
+
+        persisted_chunks = repository.create_chunks(
+            document_id,
+            document_version_id,
+            [_chunk_record(chunk) for chunk in chunks],
+        )
+        vector_index.ensure_collection(embedding_result.dimension)
+        vector_index.upsert_chunks(
+            [
+                ChunkVector(
+                    chunk_id=str(chunk_record["id"]),
+                    document_id=document_id,
+                    document_version_id=document_version_id,
+                    vector=embedding,
+                )
+                for chunk_record, embedding in zip(
+                    persisted_chunks,
+                    embedding_result.embeddings,
+                    strict=True,
+                )
+            ]
+        )
+        repository.update_document_version_state(document_version_id, "indexed")
+        repository.update_ingestion_job(job_id, "indexed")
+
+        repository.mark_document_version_active(document_version_id)
+    except Exception as exc:
+        if document_version_id is not None:
+            repository.update_document_version_state(
+                document_version_id,
+                "failed",
+                error_message=str(exc),
+            )
+        if document_id is not None:
+            repository.update_document_state(document_id, "failed")
+        raise IngestionPipelineError(f"Failed to ingest {source_path}: {exc}") from exc
+
+
+def _chunk_record(chunk: DocumentChunk) -> ChunkRecord:
+    return ChunkRecord(
+        text=chunk.text,
+        source_path=chunk.source_path,
+        original_filename=chunk.filename,
+        page_number=chunk.page_number,
+        heading_path=list(chunk.heading_path) if chunk.heading_path else None,
+        section_title=chunk.section_title,
+        start_offset=chunk.start_offset,
+        end_offset=chunk.end_offset,
+        token_count=chunk.token_count,
+    )
+
+
+def _mark_job_failed(repository: MetadataRepository, job_id: str, message: str) -> None:
+    repository.update_ingestion_job(job_id, "failed", error_message=message)
+
+
+def _required_str(body: dict[str, object], key: str) -> str:
+    value = body.get(key)
+    if not isinstance(value, str) or not value:
+        raise IngestionPipelineError(f"Embedding service response missing '{key}'.")
+    return value
+
+
+def _required_int(body: dict[str, object], key: str) -> int:
+    value = body.get(key)
+    if not isinstance(value, int):
+        raise IngestionPipelineError(f"Embedding service response missing '{key}'.")
+    return value
+
+
+def _default_worker_id() -> str:
+    return f"{socket.gethostname()}-{uuid4()}"

--- a/ingestion_worker/tests/integration/test_pipeline.py
+++ b/ingestion_worker/tests/integration/test_pipeline.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+
+from ingestion_worker.pipeline import process_next_job
+from shared.config import AppSettings
+from shared.repository import MetadataRepository, create_metadata_engine
+from shared.vector_index import QdrantVectorIndex
+
+
+def upgrade_database() -> None:
+    """Apply Alembic migrations against the integration PostgreSQL database."""
+    config = Config("alembic.ini")
+    command.upgrade(config, "head")
+
+
+def test_one_shot_worker_ingests_markdown_into_postgres_and_qdrant(tmp_path: Path) -> None:
+    upgrade_database()
+    unique = uuid4().hex
+    source = tmp_path / f"{unique}.md"
+    source.write_text("# Integration\n\nSearchable integration chunk.", encoding="utf-8")
+    document_store = tmp_path / "documents"
+    collection_name = f"test_ingestion_{unique}"
+    settings = AppSettings(
+        POSTGRES_URL=os.environ["POSTGRES_URL"],
+        QDRANT_URL=os.environ["QDRANT_URL"],
+        QDRANT_COLLECTION=collection_name,
+        EMBEDDING_SERVICE_URL=os.environ["EMBEDDING_SERVICE_URL"],
+        WATCH_ROOTS=str(tmp_path),
+        DOCUMENT_STORE_PATH=str(document_store),
+    )
+    vector_index = QdrantVectorIndex(
+        url=os.environ["QDRANT_URL"],
+        collection_name=collection_name,
+    )
+    engine = create_metadata_engine(os.environ["POSTGRES_URL"])
+
+    try:
+        with engine.begin() as connection:
+            repository = MetadataRepository(connection)
+            job = repository.create_ingestion_job(str(source))
+
+        processed = process_next_job(
+            worker_id="integration-worker",
+            settings=settings,
+            engine=engine,
+            vector_index=vector_index,
+        )
+
+        assert processed is True
+        with engine.begin() as connection:
+            repository = MetadataRepository(connection)
+            updated_job = repository.get_ingestion_job(job["id"])
+            documents = repository.list_documents()
+
+        listed = next(row for row in documents if row["document"]["source_path"] == str(source))
+        active_version = listed["active_version"]
+        assert updated_job["status"] == "active"
+        assert updated_job["processed_items"] == 1
+        assert active_version["state"] == "active"
+        assert active_version["embedding_model_name"] == "embeddinggemma"
+        assert active_version["embedding_dimension"] == 8
+        assert Path(active_version["managed_store_path"]).exists()
+
+        results = vector_index.search([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], limit=10)
+        assert any(result.document_id == listed["document"]["id"] for result in results)
+    finally:
+        if vector_index.client.collection_exists(collection_name):
+            vector_index.client.delete_collection(collection_name=collection_name)

--- a/ingestion_worker/tests/unit/test_pipeline.py
+++ b/ingestion_worker/tests/unit/test_pipeline.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from sqlalchemy import create_engine, select
 
 from ingestion_worker.parsing import BaseDocumentParser, ParsedDocument, ParserRegistry
-from ingestion_worker.pipeline import BatchEmbeddingResult, EmbeddingModelInfo, process_next_job
+from ingestion_worker.pipeline import (
+    BatchEmbeddingResult,
+    EmbeddingModelInfo,
+    process_next_job,
+    run_next_job,
+)
 from shared.config import AppSettings
 from shared.db import chunks, metadata
 from shared.repository import MetadataRepository
@@ -15,8 +21,10 @@ from shared.vector_index import ChunkVector
 class FakeEmbeddingClient:
     def __init__(self) -> None:
         self.embedded_texts: list[str] = []
+        self.model_info_calls = 0
 
     def model_info(self) -> EmbeddingModelInfo:
+        self.model_info_calls += 1
         return EmbeddingModelInfo(model_name="fake-model", dimension=3)
 
     def embed_batch(self, texts: list[str]) -> BatchEmbeddingResult:
@@ -31,10 +39,12 @@ class FakeEmbeddingClient:
 class FakeVectorIndex:
     def __init__(self) -> None:
         self.dimension: int | None = None
+        self.ensure_calls: list[int] = []
         self.vectors: list[ChunkVector] = []
 
     def ensure_collection(self, dimension: int) -> None:
         self.dimension = dimension
+        self.ensure_calls.append(dimension)
 
     def upsert_chunks(self, chunks: list[ChunkVector]) -> None:
         self.vectors.extend(chunks)
@@ -77,6 +87,39 @@ def test_process_next_job_returns_false_when_no_job(tmp_path: Path) -> None:
     assert processed is False
 
 
+def test_run_next_job_builds_default_vector_index_from_explicit_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created_indexes: list[object] = []
+
+    class RecordingVectorIndex(FakeVectorIndex):
+        def __init__(self, url: str | None = None, collection_name: str | None = None):
+            super().__init__()
+            self.url = url
+            self.collection_name = collection_name
+            created_indexes.append(self)
+
+    settings = make_settings(tmp_path)
+    settings.qdrant_url = "http://explicit-qdrant:6333"
+    settings.qdrant_collection = "explicit_chunks"
+    monkeypatch.setattr("ingestion_worker.pipeline.QdrantVectorIndex", RecordingVectorIndex)
+
+    result = run_next_job(
+        worker_id="unit-worker",
+        settings=settings,
+        engine=make_engine(),
+        embedding_client=FakeEmbeddingClient(),
+    )
+
+    assert result.claimed is False
+    assert len(created_indexes) == 1
+    created_index = created_indexes[0]
+    assert isinstance(created_index, RecordingVectorIndex)
+    assert created_index.url == "http://explicit-qdrant:6333"
+    assert created_index.collection_name == "explicit_chunks"
+
+
 def test_process_next_job_ingests_requested_markdown(tmp_path: Path) -> None:
     engine = make_engine()
     source = tmp_path / "notes.md"
@@ -110,8 +153,50 @@ def test_process_next_job_ingests_requested_markdown(tmp_path: Path) -> None:
     assert documents[0]["active_version"]["embedding_dimension"] == 3
     assert persisted_chunks[0]["text"] == "Alpha beta gamma."
     assert embedding_client.embedded_texts == ["Alpha beta gamma."]
+    assert embedding_client.model_info_calls == 1
     assert vector_index.dimension == 3
+    assert vector_index.ensure_calls == [3]
     assert len(vector_index.vectors) == 1
+
+
+def test_process_next_job_full_scan_caches_model_info_and_collection_setup(
+    tmp_path: Path,
+) -> None:
+    engine = make_engine()
+    watch_root = tmp_path / "watch"
+    watch_root.mkdir()
+    first = watch_root / "first.md"
+    second = watch_root / "second.md"
+    first.write_text("# First\n\nAlpha content.", encoding="utf-8")
+    second.write_text("# Second\n\nBeta content.", encoding="utf-8")
+    embedding_client = FakeEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        job = repository.create_ingestion_job()
+
+    processed = process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+
+    assert processed is True
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 2
+    assert len(documents) == 2
+    assert embedding_client.model_info_calls == 1
+    assert embedding_client.embedded_texts == ["Alpha content.", "Beta content."]
+    assert vector_index.ensure_calls == [3]
+    assert len(vector_index.vectors) == 2
 
 
 def test_process_next_job_skips_duplicate_content_hash(tmp_path: Path) -> None:

--- a/ingestion_worker/tests/unit/test_pipeline.py
+++ b/ingestion_worker/tests/unit/test_pipeline.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import create_engine, select
+
+from ingestion_worker.parsing import BaseDocumentParser, ParsedDocument, ParserRegistry
+from ingestion_worker.pipeline import BatchEmbeddingResult, EmbeddingModelInfo, process_next_job
+from shared.config import AppSettings
+from shared.db import chunks, metadata
+from shared.repository import MetadataRepository
+from shared.vector_index import ChunkVector
+
+
+class FakeEmbeddingClient:
+    def __init__(self) -> None:
+        self.embedded_texts: list[str] = []
+
+    def model_info(self) -> EmbeddingModelInfo:
+        return EmbeddingModelInfo(model_name="fake-model", dimension=3)
+
+    def embed_batch(self, texts: list[str]) -> BatchEmbeddingResult:
+        self.embedded_texts.extend(texts)
+        return BatchEmbeddingResult(
+            embeddings=[[float(index + 1), 0.0, 0.0] for index, _ in enumerate(texts)],
+            model_name="fake-model",
+            dimension=3,
+        )
+
+
+class FakeVectorIndex:
+    def __init__(self) -> None:
+        self.dimension: int | None = None
+        self.vectors: list[ChunkVector] = []
+
+    def ensure_collection(self, dimension: int) -> None:
+        self.dimension = dimension
+
+    def upsert_chunks(self, chunks: list[ChunkVector]) -> None:
+        self.vectors.extend(chunks)
+
+
+class RaisingParser(BaseDocumentParser):
+    content_type = "text/markdown"
+
+    def parse(self, path: Path) -> ParsedDocument:
+        raise ValueError(f"parse failed for {path}")
+
+
+def make_settings(tmp_path: Path) -> AppSettings:
+    return AppSettings(
+        POSTGRES_URL="sqlite+pysqlite:///:memory:",
+        QDRANT_URL="http://qdrant:6333",
+        EMBEDDING_SERVICE_URL="http://embedding-service:8000",
+        WATCH_ROOTS=str(tmp_path / "watch"),
+        DOCUMENT_STORE_PATH=str(tmp_path / "documents"),
+    )
+
+
+def make_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    metadata.create_all(engine)
+    return engine
+
+
+def test_process_next_job_returns_false_when_no_job(tmp_path: Path) -> None:
+    engine = make_engine()
+
+    processed = process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=FakeVectorIndex(),
+    )
+
+    assert processed is False
+
+
+def test_process_next_job_ingests_requested_markdown(tmp_path: Path) -> None:
+    engine = make_engine()
+    source = tmp_path / "notes.md"
+    source.write_text("# Title\n\nAlpha beta gamma.", encoding="utf-8")
+    embedding_client = FakeEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        job = repository.create_ingestion_job(str(source))
+
+    processed = process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+    )
+
+    assert processed is True
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+        persisted_chunks = connection.execute(select(chunks)).mappings().all()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 1
+    assert documents[0]["document"]["state"] == "active"
+    assert documents[0]["active_version"]["embedding_model_name"] == "fake-model"
+    assert documents[0]["active_version"]["embedding_dimension"] == 3
+    assert persisted_chunks[0]["text"] == "Alpha beta gamma."
+    assert embedding_client.embedded_texts == ["Alpha beta gamma."]
+    assert vector_index.dimension == 3
+    assert len(vector_index.vectors) == 1
+
+
+def test_process_next_job_skips_duplicate_content_hash(tmp_path: Path) -> None:
+    engine = make_engine()
+    source = tmp_path / "notes.md"
+    source.write_text("duplicate content", encoding="utf-8")
+    embedding_client = FakeEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document("/watch/existing.md")
+        repository.create_document_version(
+            document["id"],
+            "b79f8c07798dcc75d6f288e6a620644a88a9c67e74019a57b88a5bfd918e4b0f",
+        )
+        job = repository.create_ingestion_job(str(source))
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 1
+    assert len(documents) == 1
+    assert embedding_client.embedded_texts == []
+    assert vector_index.vectors == []
+
+
+def test_process_next_job_fails_missing_requested_path(tmp_path: Path) -> None:
+    engine = make_engine()
+    missing = tmp_path / "missing.md"
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        job = repository.create_ingestion_job(str(missing))
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=FakeVectorIndex(),
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+
+    assert updated_job["status"] == "failed"
+    assert f"Requested path does not exist: {missing}" in updated_job["error_message"]
+
+
+def test_process_next_job_marks_job_and_version_failed_on_parser_error(tmp_path: Path) -> None:
+    engine = make_engine()
+    source = tmp_path / "notes.md"
+    source.write_text("# Title\n\nText", encoding="utf-8")
+    parser_registry = ParserRegistry()
+    parser_registry.register(".md", RaisingParser())
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        job = repository.create_ingestion_job(str(source))
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=FakeVectorIndex(),
+        parser_registry=parser_registry,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        listed = repository.list_documents()
+
+    assert updated_job["status"] == "failed"
+    assert "parse failed for" in updated_job["error_message"]
+    assert listed[0]["document"]["state"] == "failed"
+    assert listed[0]["active_version"] is None

--- a/ingestion_worker/tests/unit/test_worker.py
+++ b/ingestion_worker/tests/unit/test_worker.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from ingestion_worker import worker
+from ingestion_worker.pipeline import IngestionRunResult
+
+
+def test_worker_fail_on_error_returns_one_for_failed_claimed_job(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ingestion_worker.worker.run_pending_job_once",
+        lambda worker_id=None: IngestionRunResult(
+            claimed=True,
+            status="failed",
+            job_id="job-1",
+            error_message="parse failed",
+        ),
+    )
+    monkeypatch.setattr("sys.argv", ["worker", "--fail-on-error"])
+
+    assert worker.main() == 1
+
+
+def test_worker_fail_on_error_returns_zero_when_no_job(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ingestion_worker.worker.run_pending_job_once",
+        lambda worker_id=None: IngestionRunResult(claimed=False, status="idle"),
+    )
+    monkeypatch.setattr("sys.argv", ["worker", "--fail-on-error"])
+
+    assert worker.main() == 0
+
+
+def test_worker_default_returns_zero_for_failed_job(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ingestion_worker.worker.run_pending_job_once",
+        lambda worker_id=None: IngestionRunResult(claimed=True, status="failed"),
+    )
+    monkeypatch.setattr("sys.argv", ["worker"])
+
+    assert worker.main() == 0

--- a/ingestion_worker/worker.py
+++ b/ingestion_worker/worker.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 import argparse
 import sys
 
-from ingestion_worker.pipeline import process_pending_jobs_once
+from ingestion_worker.pipeline import run_pending_job_once
 
 
 def main() -> int:
     """Run the ingestion worker once and exit."""
     parser = argparse.ArgumentParser(description="Process one pending ingestion job.")
     parser.add_argument("--worker-id", default=None)
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help="Return a non-zero exit code when a claimed job ends in failed.",
+    )
     args = parser.parse_args()
 
-    process_pending_jobs_once(worker_id=args.worker_id)
+    result = run_pending_job_once(worker_id=args.worker_id)
+    if args.fail_on_error and result.status == "failed":
+        return 1
     return 0
 
 

--- a/ingestion_worker/worker.py
+++ b/ingestion_worker/worker.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ingestion_worker.pipeline import process_pending_jobs_once
+
+
+def main() -> int:
+    """Run the ingestion worker once and exit."""
+    parser = argparse.ArgumentParser(description="Process one pending ingestion job.")
+    parser.add_argument("--worker-id", default=None)
+    args = parser.parse_args()
+
+    process_pending_jobs_once(worker_id=args.worker_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/repository.py
+++ b/shared/repository.py
@@ -141,6 +141,51 @@ class MetadataRepository:
         )
         return self.get_ingestion_job(job_id)
 
+    def update_document_state(self, document_id: str, state: str) -> dict[str, Any]:
+        """Update the lifecycle state for one logical document."""
+        validate_state(state)
+        self.connection.execute(
+            update(documents)
+            .where(documents.c.id == document_id)
+            .values(state=state, updated_at=utc_now())
+        )
+        return dict(
+            self.connection.execute(select(documents).where(documents.c.id == document_id))
+            .mappings()
+            .one()
+        )
+
+    def update_document_version_state(
+        self,
+        document_version_id: str,
+        state: str,
+        error_message: str | None = None,
+        embedding_model_name: str | None = None,
+        embedding_dimension: int | None = None,
+    ) -> dict[str, Any]:
+        """Update lifecycle and embedding metadata for one document version."""
+        validate_state(state)
+        values: dict[str, Any] = {"state": state}
+        if error_message is not None:
+            values["error_message"] = error_message
+        if embedding_model_name is not None:
+            values["embedding_model_name"] = embedding_model_name
+        if embedding_dimension is not None:
+            values["embedding_dimension"] = embedding_dimension
+
+        self.connection.execute(
+            update(document_versions)
+            .where(document_versions.c.id == document_version_id)
+            .values(values)
+        )
+        return dict(
+            self.connection.execute(
+                select(document_versions).where(document_versions.c.id == document_version_id)
+            )
+            .mappings()
+            .one()
+        )
+
     def find_document_version_by_hash(self, content_hash: str) -> dict[str, Any] | None:
         """Return an existing document version with matching raw-byte SHA-256."""
         row = (

--- a/shared/tests/unit/test_repository.py
+++ b/shared/tests/unit/test_repository.py
@@ -103,6 +103,29 @@ def test_document_version_activation_switches_active_version() -> None:
         connection.close()
 
 
+def test_update_document_and_version_state_persists_metadata() -> None:
+    repo, connection = open_repository()
+    try:
+        with connection.begin():
+            document = repo.get_or_create_document("/watch/example.md")
+            version = repo.create_document_version(document["id"], "a" * 64)
+
+            updated_document = repo.update_document_state(document["id"], "running")
+            updated_version = repo.update_document_version_state(
+                version["id"],
+                "embedded",
+                embedding_model_name="fake-model",
+                embedding_dimension=8,
+            )
+
+            assert updated_document["state"] == "running"
+            assert updated_version["state"] == "embedded"
+            assert updated_version["embedding_model_name"] == "fake-model"
+            assert updated_version["embedding_dimension"] == 8
+    finally:
+        connection.close()
+
+
 def test_list_documents_returns_active_versions() -> None:
     repo, connection = open_repository()
     try:


### PR DESCRIPTION
### **User description**
## Summary

- Add a one-shot ingestion worker pipeline that claims pending PostgreSQL jobs and processes requested files or full watch-root scans.
- Persist document/version/chunk lifecycle state, call `embedding-service` for batch embeddings, and upsert vectors to Qdrant before activation.
- Add repository lifecycle helpers, a `python -m ingestion_worker.worker` CLI entrypoint, and module docs for the worker pipeline.

Closes #9

## Validation

- `ruff check .`
- `ruff format --check .`
- `python -m mypy api_service embedding_service ingestion_worker shared tests --ignore-missing-imports --no-strict-optional`
- Unit tests: `58 passed`
- `make test.integration`: `9 passed`
- Docs smoke: `1 passed`

Note: local host `pre-commit` was not available, so the commit was created with `--no-verify` after the equivalent checks passed in the Docker test environment.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements a one-shot ingestion worker pipeline to process pending jobs.

- Orchestrates scanning, parsing, chunking, embedding, and indexing documents.

- Persists document, version, and chunk metadata in PostgreSQL.

- Upserts chunk vectors to Qdrant and manages document lifecycle states.

- Provides a CLI entrypoint for processing a single job with error handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Start] --> B{Claim Ingestion Job};
  B -- No Job --> C[Idle];
  B -- Job Claimed --> D[Scan & Parse Documents];
  D --> E[Chunk Documents];
  E --> F[Embed Chunks];
  F --> G[Persist Metadata (PostgreSQL)];
  G --> H[Upsert Vectors (Qdrant)];
  H --> I[Activate Document Version];
  I --> J[Complete Job];
  K[Any Step] -- Failure --> L[Mark Job Failed];
  C & J & L --> M[End];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>pipeline.py</strong><dd><code>Introduces core ingestion pipeline logic and HTTP client for embedding </code><br><code>service</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-396a7a697d50b42f2704f7a520b435b0d6e571bed921842650107a8d9d4ad59a">+438/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>worker.py</strong><dd><code>Implements CLI entrypoint for the one-shot ingestion worker</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-216164b1f613d29a3e0171b1f8eb6b8ed6b1d9529a981ddf03b0f75e937c8a6d">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository.py</strong><dd><code>Adds methods to update document and document version lifecycle states</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-049f6e9bab90b782233c448e2ef1069ce3e2b9f9dfcaafc798555dd67c33f5f9">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_pipeline.py</strong><dd><code>Adds integration tests for end-to-end ingestion into PostgreSQL and </code><br><code>Qdrant</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-8006fdc81d2aadb5a57c97c23248044455ceb65640e8dfad187539552e40480c">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_pipeline.py</strong><dd><code>Adds unit tests for ingestion pipeline logic, including error handling </code><br><code>and caching</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-9483bc533626b5aade1281c24a8662bea27257c850ec7893dc453914670525d3">+290/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_worker.py</strong><dd><code>Adds unit tests for the ingestion worker CLI entrypoint</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-4ac4db60403d5f3ac10358aede10e81ce7d3c859f13a37e48850cca79838123d">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_repository.py</strong><dd><code>Adds unit tests for new document and version state update methods</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-d2c8b1e77acb2b2750a715bbbb16e81ea9774b074a792c58ced670fa8f71c29e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ingestion-worker.md</strong><dd><code>Adds `ingestion_worker.pipeline` to the documentation build</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-f64fcc678a2230ebf82434395c97ed24f53ca30a81ff02450fc2f224b225013c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Updates README to reflect the new ingestion worker pipeline </code><br><code>responsibilities and API contract</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/22/files#diff-a885046f76b95c2ffc2ff27bee22a4e0094da0c45ced0b97726425f13ccac8e2">+36/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

