### PR TITLE
[codex] Implement search endpoint

### DIFF
--- a/api_service/README.md
+++ b/api_service/README.md
@@ -18,18 +18,24 @@ Implemented in this skeleton:
 | `POST` | `/ingest` | Create an ingestion job |
 | `GET` | `/ingest/{job_id}` | Inspect ingestion job status |
 | `GET` | `/documents` | List ingested documents |
+| `POST` | `/search` | Return dense retrieval results with citation metadata |
 
 Planned:
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `POST` | `/chat` | Generate an answer grounded in retrieved chunks |
-| `POST` | `/search` | Return ranked chunks without generation |
 | `DELETE` | `/documents/{id}` | Delete a document from the corpus |
 
 The ingestion and document endpoints require `Authorization: Bearer <RAG_API_KEY>`.
 `POST /ingest` accepts an optional `requested_path` JSON field for single-file
 ingestion; omitting it creates a full-scan job.
+
+`POST /search` accepts a non-empty `query` string and optional `limit` integer.
+It embeds the query through `embedding-service`, searches the configured Qdrant
+collection, loads active chunk metadata from PostgreSQL, and returns ranked
+results with citation fields. Sparse PostgreSQL full-text search is not wired
+yet because the current schema has no FTS index support.
 
 ## Configuration
 

--- a/api_service/README.md
+++ b/api_service/README.md
@@ -31,7 +31,8 @@ The ingestion and document endpoints require `Authorization: Bearer <RAG_API_KEY
 `POST /ingest` accepts an optional `requested_path` JSON field for single-file
 ingestion; omitting it creates a full-scan job.
 
-`POST /search` accepts a non-empty `query` string and optional `limit` integer.
+`POST /search` accepts a non-empty `query` string and optional `limit` integer
+from 1 through 100.
 It embeds the query through `embedding-service`, searches the configured Qdrant
 collection, loads active chunk metadata from PostgreSQL, and returns ranked
 results with citation fields. Sparse PostgreSQL full-text search is not wired

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -8,6 +8,13 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoResultFound
 
+from api_service.retrieval import (
+    HttpQueryEmbeddingClient,
+    QueryEmbeddingClient,
+    RetrievalError,
+    SearchRetriever,
+    VectorIndex,
+)
 from shared.config import get_settings
 from shared.logging_config import configure_logging
 from shared.repository import MetadataRepository, create_metadata_engine
@@ -17,7 +24,10 @@ from shared.schemas import (
     HealthResponse,
     IngestionJobResponse,
     IngestRequest,
+    SearchRequest,
+    SearchResponse,
 )
+from shared.vector_index import QdrantVectorIndex
 
 configure_logging()
 
@@ -29,6 +39,18 @@ bearer_auth = HTTPBearer(auto_error=False)
 def get_metadata_engine() -> Engine:
     """Return the configured PostgreSQL metadata engine for API requests."""
     return create_metadata_engine(get_settings().postgres_url)
+
+
+@lru_cache
+def get_query_embedding_client() -> QueryEmbeddingClient:
+    """Return the embedding-service client used for interactive search queries."""
+    return HttpQueryEmbeddingClient(get_settings().embedding_service_url)
+
+
+@lru_cache
+def get_vector_index() -> VectorIndex:
+    """Return the configured Qdrant vector index for retrieval."""
+    return QdrantVectorIndex()
 
 
 def open_metadata_repository() -> Iterator[MetadataRepository]:
@@ -107,3 +129,28 @@ def list_documents(
         for row in repository.list_documents()
     ]
     return DocumentListResponse(documents=documents)
+
+
+@app.post(
+    "/search",
+    response_model=SearchResponse,
+    dependencies=[Depends(require_api_key)],
+)
+def search(
+    request: SearchRequest,
+    repository: Annotated[MetadataRepository, Depends(open_metadata_repository)],
+    embedding_client: Annotated[QueryEmbeddingClient, Depends(get_query_embedding_client)],
+    vector_index: Annotated[VectorIndex, Depends(get_vector_index)],
+) -> SearchResponse:
+    retriever = SearchRetriever(
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+    )
+    try:
+        results = retriever.search(request.query, request.limit, repository)
+    except RetrievalError as error:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(error),
+        ) from error
+    return SearchResponse(results=results)

--- a/api_service/retrieval.py
+++ b/api_service/retrieval.py
@@ -28,7 +28,15 @@ class QueryEmbeddingClient(Protocol):
         """Embed a user query for retrieval."""
 
 
+class ReadableResponse(Protocol):
+    def read(self) -> bytes:
+        """Read the raw response body bytes."""
+
+
 class VectorIndex(Protocol):
+    def ensure_collection(self, dimension: int) -> None:
+        """Create or verify the vector collection for the embedding dimension."""
+
     def search(self, query_vector: list[float], limit: int) -> list[VectorSearchResult]:
         """Return ranked dense retrieval candidates."""
 
@@ -51,9 +59,9 @@ class HttpQueryEmbeddingClient:
         )
         try:
             with request.urlopen(req, timeout=self.timeout_seconds) as response:
-                body = json.loads(response.read().decode("utf-8"))
+                body = _read_json_response(response)
         except error.HTTPError as exc:
-            detail = exc.read().decode("utf-8")
+            detail = _read_http_error_detail(exc)
             raise RetrievalError(f"Embedding service HTTP error: {detail}") from exc
         except error.URLError as exc:
             raise RetrievalError(f"Embedding service unavailable: {exc.reason}") from exc
@@ -86,7 +94,13 @@ class SearchRetriever:
     ) -> list[SearchResult]:
         """Return citation-ready results ranked by dense vector search score."""
         embedding = self.embedding_client.embed_query(query)
-        dense_results = self.vector_index.search(embedding.embedding, limit)
+        try:
+            self.vector_index.ensure_collection(embedding.dimension)
+            dense_results = self.vector_index.search(embedding.embedding, limit)
+        except RetrievalError:
+            raise
+        except Exception as exc:
+            raise RetrievalError("Vector index search failed.") from exc
         chunks_by_id = repository.get_active_chunks_by_ids(
             [result.chunk_id for result in dense_results]
         )
@@ -113,6 +127,27 @@ class SearchRetriever:
                 )
             )
         return results
+
+
+def _read_json_response(response: ReadableResponse) -> dict[str, object]:
+    try:
+        raw_body = response.read()
+        if not isinstance(raw_body, bytes):
+            raise RetrievalError("Embedding service returned a non-bytes response.")
+        body = json.loads(raw_body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RetrievalError("Embedding service returned an invalid JSON response.") from exc
+
+    if not isinstance(body, dict):
+        raise RetrievalError("Embedding service returned a non-object response.")
+    return body
+
+
+def _read_http_error_detail(exc: error.HTTPError) -> str:
+    try:
+        return exc.read().decode("utf-8")
+    except UnicodeDecodeError:
+        return "<non-UTF-8 response body>"
 
 
 def _required_str(body: dict[str, object], key: str) -> str:

--- a/api_service/retrieval.py
+++ b/api_service/retrieval.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Protocol
+from urllib import error, request
+
+from shared.repository import MetadataRepository
+from shared.schemas import SearchResult
+from shared.vector_index import VectorSearchResult
+
+
+class RetrievalError(RuntimeError):
+    """Raised when retrieval cannot call or parse a required backend response."""
+
+
+@dataclass(frozen=True)
+class QueryEmbedding:
+    """Embedding-service response for one interactive search query."""
+
+    embedding: list[float]
+    model_name: str
+    dimension: int
+
+
+class QueryEmbeddingClient(Protocol):
+    def embed_query(self, query: str) -> QueryEmbedding:
+        """Embed a user query for retrieval."""
+
+
+class VectorIndex(Protocol):
+    def search(self, query_vector: list[float], limit: int) -> list[VectorSearchResult]:
+        """Return ranked dense retrieval candidates."""
+
+
+class HttpQueryEmbeddingClient:
+    """Small HTTP client for the embedding-service single-query API."""
+
+    def __init__(self, base_url: str, timeout_seconds: int = 10) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def embed_query(self, query: str) -> QueryEmbedding:
+        """Embed one search query through `POST /embed`."""
+        payload = json.dumps({"text": query}).encode("utf-8")
+        req = request.Request(
+            url=f"{self.base_url}/embed",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8")
+            raise RetrievalError(f"Embedding service HTTP error: {detail}") from exc
+        except error.URLError as exc:
+            raise RetrievalError(f"Embedding service unavailable: {exc.reason}") from exc
+
+        if not isinstance(body, dict):
+            raise RetrievalError("Embedding service returned a non-object response.")
+        embedding = body.get("embedding")
+        if not isinstance(embedding, list):
+            raise RetrievalError("Embedding service returned invalid embedding data.")
+
+        return QueryEmbedding(
+            embedding=[float(value) for value in embedding],
+            model_name=_required_str(body, "model_name"),
+            dimension=_required_int(body, "dimension"),
+        )
+
+
+@dataclass
+class SearchRetriever:
+    """Orchestrate dense retrieval and loading active chunk metadata for API search."""
+
+    embedding_client: QueryEmbeddingClient
+    vector_index: VectorIndex
+
+    def search(
+        self,
+        query: str,
+        limit: int,
+        repository: MetadataRepository,
+    ) -> list[SearchResult]:
+        """Return citation-ready results ranked by dense vector search score."""
+        embedding = self.embedding_client.embed_query(query)
+        dense_results = self.vector_index.search(embedding.embedding, limit)
+        chunks_by_id = repository.get_active_chunks_by_ids(
+            [result.chunk_id for result in dense_results]
+        )
+
+        results: list[SearchResult] = []
+        for dense_result in dense_results:
+            chunk = chunks_by_id.get(dense_result.chunk_id)
+            if chunk is None:
+                continue
+            results.append(
+                SearchResult(
+                    score=dense_result.score,
+                    text=chunk["text"],
+                    document_id=chunk["document_id"],
+                    document_version_id=chunk["document_version_id"],
+                    chunk_id=chunk["id"],
+                    source_path=chunk["source_path"],
+                    original_filename=chunk["original_filename"],
+                    page_number=chunk["page_number"],
+                    heading_path=chunk["heading_path"],
+                    section_title=chunk["section_title"],
+                    start_offset=chunk["start_offset"],
+                    end_offset=chunk["end_offset"],
+                )
+            )
+        return results
+
+
+def _required_str(body: dict[str, object], key: str) -> str:
+    value = body.get(key)
+    if not isinstance(value, str) or not value:
+        raise RetrievalError(f"Embedding service response missing '{key}'.")
+    return value
+
+
+def _required_int(body: dict[str, object], key: str) -> int:
+    value = body.get(key)
+    if not isinstance(value, int):
+        raise RetrievalError(f"Embedding service response missing '{key}'.")
+    return value

--- a/api_service/tests/integration/test_ingestion_document_endpoints.py
+++ b/api_service/tests/integration/test_ingestion_document_endpoints.py
@@ -5,7 +5,7 @@ import httpx
 from alembic import command
 from alembic.config import Config
 
-from embedding_service.main import fake_embedding
+from embedding_service.testing.mocks import make_fake_embedding
 from shared.repository import ChunkRecord, MetadataRepository, create_metadata_engine
 from shared.vector_index import ChunkVector, QdrantVectorIndex
 
@@ -119,7 +119,7 @@ def test_search_endpoint_returns_qdrant_backed_citations() -> None:
                     chunk_id=chunks[0]["id"],
                     document_id=document["id"],
                     document_version_id=version["id"],
-                    vector=fake_embedding(query, 8),
+                    vector=make_fake_embedding(query, 8),
                 )
             ]
         )

--- a/api_service/tests/integration/test_ingestion_document_endpoints.py
+++ b/api_service/tests/integration/test_ingestion_document_endpoints.py
@@ -5,7 +5,9 @@ import httpx
 from alembic import command
 from alembic.config import Config
 
-from shared.repository import MetadataRepository, create_metadata_engine
+from embedding_service.main import fake_embedding
+from shared.repository import ChunkRecord, MetadataRepository, create_metadata_engine
+from shared.vector_index import ChunkVector, QdrantVectorIndex
 
 
 def upgrade_database() -> None:
@@ -75,3 +77,68 @@ def test_documents_endpoint_lists_metadata_backed_documents() -> None:
     listed = next(document for document in documents if document["source_path"] == source_path)
     assert listed["id"] == document["id"]
     assert listed["active_version"]["id"] == version["id"]
+
+
+def test_search_endpoint_returns_qdrant_backed_citations() -> None:
+    upgrade_database()
+    base_url = os.environ["API_SERVICE_URL"]
+    query = f"searchable integration phrase {uuid4().hex}"
+    unique = uuid4().hex
+    source_path = f"/watch/{unique}.md"
+
+    engine = create_metadata_engine(os.environ["POSTGRES_URL"])
+    vector_index = QdrantVectorIndex(url=os.environ["QDRANT_URL"])
+    vector_index.ensure_collection(8)
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document(source_path)
+        version = repository.create_document_version(document["id"], f"{unique}{unique}")
+        chunks = repository.create_chunks(
+            document["id"],
+            version["id"],
+            [
+                ChunkRecord(
+                    text="Integration search result",
+                    source_path=source_path,
+                    original_filename=f"{unique}.md",
+                    page_number=2,
+                    heading_path=["Integration"],
+                    section_title="Integration",
+                    start_offset=0,
+                    end_offset=25,
+                )
+            ],
+        )
+        repository.mark_document_version_active(version["id"])
+
+    try:
+        vector_index.upsert_chunks(
+            [
+                ChunkVector(
+                    chunk_id=chunks[0]["id"],
+                    document_id=document["id"],
+                    document_version_id=version["id"],
+                    vector=fake_embedding(query, 8),
+                )
+            ]
+        )
+
+        response = httpx.post(
+            f"{base_url}/search",
+            json={"query": query, "limit": 1},
+            headers=auth_headers(),
+            timeout=5,
+        )
+
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["chunk_id"] == chunks[0]["id"]
+        assert results[0]["document_id"] == document["id"]
+        assert results[0]["document_version_id"] == version["id"]
+        assert results[0]["source_path"] == source_path
+        assert results[0]["page_number"] == 2
+        assert results[0]["heading_path"] == ["Integration"]
+    finally:
+        vector_index.delete_by_document_id(document["id"])

--- a/api_service/tests/unit/test_ingestion_document_contracts.py
+++ b/api_service/tests/unit/test_ingestion_document_contracts.py
@@ -76,10 +76,17 @@ class FakeQueryEmbeddingClient:
 class FakeVectorIndex:
     def __init__(self) -> None:
         self.results: list[VectorSearchResult] = []
+        self.ensured_dimensions: list[int] = []
         self.query_vector: list[float] | None = None
         self.limit: int | None = None
+        self.error: RuntimeError | None = None
+
+    def ensure_collection(self, dimension: int) -> None:
+        self.ensured_dimensions.append(dimension)
 
     def search(self, query_vector: list[float], limit: int) -> list[VectorSearchResult]:
+        if self.error is not None:
+            raise self.error
         self.query_vector = query_vector
         self.limit = limit
         return self.results
@@ -95,6 +102,17 @@ def test_search_requires_api_key(client: TestClient) -> None:
     response = client.post("/search", json={"query": "example"})
 
     assert response.status_code == 401
+
+
+@pytest.mark.parametrize("limit", [0, -1, 101])
+def test_search_rejects_invalid_limit(client: TestClient, limit: int) -> None:
+    response = client.post(
+        "/search",
+        json={"query": "example", "limit": limit},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 422
 
 
 def test_post_ingest_creates_pending_job(client: TestClient) -> None:
@@ -197,6 +215,7 @@ def test_search_returns_citation_ready_chunks(
 
     assert response.status_code == 200
     assert embedding_client.queries == ["alpha"]
+    assert vector_index.ensured_dimensions == [3]
     assert vector_index.query_vector == [1.0, 0.0, 0.0]
     assert vector_index.limit == 5
     body = response.json()
@@ -314,3 +333,20 @@ def test_search_returns_bad_gateway_for_embedding_failure(client: TestClient) ->
 
     assert response.status_code == 502
     assert response.json()["detail"] == "Embedding service unavailable: refused"
+
+
+def test_search_returns_bad_gateway_for_vector_index_failure(client: TestClient) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+    vector_index.error = RuntimeError("qdrant unavailable")
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+
+    response = client.post(
+        "/search",
+        json={"query": "alpha"},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Vector index search failed."

--- a/api_service/tests/unit/test_ingestion_document_contracts.py
+++ b/api_service/tests/unit/test_ingestion_document_contracts.py
@@ -6,10 +6,18 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.pool import StaticPool
 
-from api_service.main import app, get_metadata_engine, open_metadata_repository
+from api_service.main import (
+    app,
+    get_metadata_engine,
+    get_query_embedding_client,
+    get_vector_index,
+    open_metadata_repository,
+)
+from api_service.retrieval import QueryEmbedding, RetrievalError
 from shared.config import get_settings
 from shared.db import metadata
-from shared.repository import MetadataRepository
+from shared.repository import ChunkRecord, MetadataRepository
+from shared.vector_index import VectorSearchResult
 
 
 @pytest.fixture
@@ -49,8 +57,42 @@ def auth_headers() -> dict[str, str]:
     return {"Authorization": "Bearer unit-token"}
 
 
+class FakeQueryEmbeddingClient:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+        self.error: RetrievalError | None = None
+
+    def embed_query(self, query: str) -> QueryEmbedding:
+        self.queries.append(query)
+        if self.error is not None:
+            raise self.error
+        return QueryEmbedding(
+            embedding=[1.0, 0.0, 0.0],
+            model_name="fake-model",
+            dimension=3,
+        )
+
+
+class FakeVectorIndex:
+    def __init__(self) -> None:
+        self.results: list[VectorSearchResult] = []
+        self.query_vector: list[float] | None = None
+        self.limit: int | None = None
+
+    def search(self, query_vector: list[float], limit: int) -> list[VectorSearchResult]:
+        self.query_vector = query_vector
+        self.limit = limit
+        return self.results
+
+
 def test_protected_endpoints_require_api_key(client: TestClient) -> None:
     response = client.post("/ingest")
+
+    assert response.status_code == 401
+
+
+def test_search_requires_api_key(client: TestClient) -> None:
+    response = client.post("/search", json={"query": "example"})
 
     assert response.status_code == 401
 
@@ -105,3 +147,170 @@ def test_get_documents_lists_metadata_backed_documents(
     assert listed["id"] == document["id"]
     assert listed["source_path"] == "/watch/example.md"
     assert listed["active_version"]["id"] == version["id"]
+
+
+def test_search_returns_citation_ready_chunks(
+    client: TestClient,
+    engine: Engine,
+) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document("/watch/example.md")
+        version = repository.create_document_version(document["id"], "a" * 64)
+        chunks = repository.create_chunks(
+            document["id"],
+            version["id"],
+            [
+                ChunkRecord(
+                    text="Alpha content",
+                    source_path="/watch/example.md",
+                    original_filename="example.md",
+                    page_number=3,
+                    heading_path=["Root", "Alpha"],
+                    section_title="Alpha",
+                    start_offset=10,
+                    end_offset=23,
+                )
+            ],
+        )
+        repository.mark_document_version_active(version["id"])
+
+    vector_index.results = [
+        VectorSearchResult(
+            chunk_id=chunks[0]["id"],
+            document_id=document["id"],
+            document_version_id=version["id"],
+            score=0.92,
+        )
+    ]
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+
+    response = client.post(
+        "/search",
+        json={"query": "alpha", "limit": 5},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert embedding_client.queries == ["alpha"]
+    assert vector_index.query_vector == [1.0, 0.0, 0.0]
+    assert vector_index.limit == 5
+    body = response.json()
+    assert body["results"] == [
+        {
+            "score": 0.92,
+            "text": "Alpha content",
+            "document_id": document["id"],
+            "document_version_id": version["id"],
+            "chunk_id": chunks[0]["id"],
+            "source_path": "/watch/example.md",
+            "original_filename": "example.md",
+            "page_number": 3,
+            "heading_path": ["Root", "Alpha"],
+            "section_title": "Alpha",
+            "start_offset": 10,
+            "end_offset": 23,
+        }
+    ]
+
+
+def test_search_returns_empty_results_when_vector_search_is_empty(client: TestClient) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+
+    response = client.post(
+        "/search",
+        json={"query": "alpha"},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"results": []}
+
+
+def test_search_excludes_stale_document_versions(
+    client: TestClient,
+    engine: Engine,
+) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document("/watch/example.md")
+        old_version = repository.create_document_version(document["id"], "a" * 64)
+        active_version = repository.create_document_version(document["id"], "b" * 64)
+        stale_chunks = repository.create_chunks(
+            document["id"],
+            old_version["id"],
+            [
+                ChunkRecord(
+                    text="Old content",
+                    source_path="/watch/example.md",
+                    original_filename="example.md",
+                )
+            ],
+        )
+        active_chunks = repository.create_chunks(
+            document["id"],
+            active_version["id"],
+            [
+                ChunkRecord(
+                    text="Current content",
+                    source_path="/watch/example.md",
+                    original_filename="example.md",
+                )
+            ],
+        )
+        repository.mark_document_version_active(active_version["id"])
+
+    vector_index.results = [
+        VectorSearchResult(
+            chunk_id=stale_chunks[0]["id"],
+            document_id=document["id"],
+            document_version_id=old_version["id"],
+            score=0.99,
+        ),
+        VectorSearchResult(
+            chunk_id=active_chunks[0]["id"],
+            document_id=document["id"],
+            document_version_id=active_version["id"],
+            score=0.9,
+        ),
+    ]
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+
+    response = client.post(
+        "/search",
+        json={"query": "current"},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["chunk_id"] == active_chunks[0]["id"]
+    assert results[0]["text"] == "Current content"
+
+
+def test_search_returns_bad_gateway_for_embedding_failure(client: TestClient) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    embedding_client.error = RetrievalError("Embedding service unavailable: refused")
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: FakeVectorIndex()
+
+    response = client.post(
+        "/search",
+        json={"query": "alpha"},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Embedding service unavailable: refused"

--- a/api_service/tests/unit/test_retrieval.py
+++ b/api_service/tests/unit/test_retrieval.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from email.message import Message
+from io import BytesIO
+from urllib import error
+
+import pytest
+
+from api_service import retrieval
+from api_service.retrieval import HttpQueryEmbeddingClient, RetrievalError
+
+
+class FakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_embedding_client_rejects_invalid_json_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(*args: object, **kwargs: object) -> FakeResponse:
+        return FakeResponse(b"<html>not json</html>")
+
+    monkeypatch.setattr(retrieval.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RetrievalError, match="invalid JSON response"):
+        HttpQueryEmbeddingClient("http://embedding-service").embed_query("alpha")
+
+
+def test_embedding_client_rejects_invalid_utf8_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(*args: object, **kwargs: object) -> FakeResponse:
+        return FakeResponse(b"\xff")
+
+    monkeypatch.setattr(retrieval.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RetrievalError, match="invalid JSON response"):
+        HttpQueryEmbeddingClient("http://embedding-service").embed_query("alpha")
+
+
+def test_embedding_client_handles_non_utf8_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(*args: object, **kwargs: object) -> FakeResponse:
+        raise error.HTTPError(
+            url="http://embedding-service/embed",
+            code=502,
+            msg="Bad Gateway",
+            hdrs=Message(),
+            fp=BytesIO(b"\xff"),
+        )
+
+    monkeypatch.setattr(retrieval.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RetrievalError, match="<non-UTF-8 response body>"):
+        HttpQueryEmbeddingClient("http://embedding-service").embed_query("alpha")

--- a/docs/modules/retrieval.md
+++ b/docs/modules/retrieval.md
@@ -1,15 +1,22 @@
 # Retrieval
 
-Retrieval is initially implemented inside `api-service`.
+Retrieval is implemented inside `api-service`.
 
 Responsibilities:
 
 - Embed user queries through `embedding-service`.
 - Retrieve dense candidates through the shared Qdrant vector-index client.
-- Retrieve sparse/exact-match candidates through PostgreSQL FTS or another self-hosted sparse index.
-- Merge candidates with a deterministic rank-fusion strategy.
-- Apply answerability gates before generation.
+- Load active chunk metadata from PostgreSQL.
 - Return citations with document, version, chunk, and source metadata.
+
+The current `POST /search` implementation is dense-only. Sparse/exact-match
+retrieval remains a follow-up because the current PostgreSQL schema does not yet
+include full-text search support. When sparse retrieval is added, results should
+be merged with dense candidates through a simple deterministic rank-fusion
+strategy.
+
+Answerability gates are planned for `POST /chat`, which will build on this
+retrieval path before generation.
 
 Related decisions:
 

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -30,7 +30,7 @@ metadata service.
 Qdrant stores chunk embeddings in the configured `QDRANT_COLLECTION`. Services use
 `shared.vector_index.QdrantVectorIndex` to create or verify the collection, upsert
 chunk vectors, delete vectors by document or document version, and run dense vector
-searches that return payload IDs for PostgreSQL metadata hydration.
+searches that return payload IDs used to load chunk metadata from PostgreSQL.
 
 Related decisions:
 

--- a/docs/schemas/api.md
+++ b/docs/schemas/api.md
@@ -11,7 +11,7 @@ Search schemas:
 
 | Schema | Purpose |
 |--------|---------|
-| `SearchRequest` | Request body for `POST /search`: non-empty `query`, optional `limit` defaulting to 10 |
+| `SearchRequest` | Request body for `POST /search`: non-empty `query`, optional `limit` from 1 through 100 defaulting to 10 |
 | `SearchResponse` | Search response containing ranked `results` |
 | `SearchResult` | Citation-ready chunk result with score, text, document/version/chunk ids, source path, filename, page/heading metadata, and text offsets |
 

--- a/docs/schemas/api.md
+++ b/docs/schemas/api.md
@@ -1,7 +1,5 @@
 # API Schemas
 
-API schemas are not implemented yet.
-
 Shared conventions already exist for:
 
 | Schema | Purpose |
@@ -9,12 +7,20 @@ Shared conventions already exist for:
 | `HealthResponse` | Standard service health response: `service`, `status` |
 | `ErrorResponse` | Standard error envelope: `error`, `message`, optional `request_id` |
 
+Search schemas:
+
+| Schema | Purpose |
+|--------|---------|
+| `SearchRequest` | Request body for `POST /search`: non-empty `query`, optional `limit` defaulting to 10 |
+| `SearchResponse` | Search response containing ranked `results` |
+| `SearchResult` | Citation-ready chunk result with score, text, document/version/chunk ids, source path, filename, page/heading metadata, and text offsets |
+
 Minimum planned API surface:
 
 | Service | Endpoint | Purpose |
 |---------|----------|---------|
 | `api-service` | `POST /chat` | Chat with retrieved grounding context |
-| `api-service` | `POST /search` | Retrieve ranked results without generation |
+| `api-service` | `POST /search` | Retrieve dense ranked results without generation |
 | `api-service` | `POST /ingest` | Create an ingestion job |
 | `api-service` | `GET /ingest/{job_id}` | Inspect ingestion job status |
 | `api-service` | `GET /documents` | List ingested documents |

--- a/shared/README.md
+++ b/shared/README.md
@@ -37,7 +37,7 @@ an explicit transaction. It supports:
 `QDRANT_COLLECTION`. It creates or verifies the chunk-vector collection for a
 caller-provided embedding dimension, upserts chunk vectors, deletes vectors by
 `document_id` or `document_version_id`, and returns dense search results with
-payload IDs needed for PostgreSQL metadata hydration.
+payload IDs needed to load chunk metadata from PostgreSQL.
 
 ## Configuration
 

--- a/shared/repository.py
+++ b/shared/repository.py
@@ -345,6 +345,22 @@ class MetadataRepository:
         ).mappings()
         return [dict(row) for row in result]
 
+    def get_active_chunks_by_ids(self, chunk_ids: list[str]) -> dict[str, dict[str, Any]]:
+        """Return chunk metadata for ids that belong to active document versions."""
+        if not chunk_ids:
+            return {}
+
+        rows = self.connection.execute(
+            select(chunks)
+            .join(
+                documents,
+                (documents.c.id == chunks.c.document_id)
+                & (documents.c.active_document_version_id == chunks.c.document_version_id),
+            )
+            .where(chunks.c.id.in_(chunk_ids))
+        ).mappings()
+        return {str(row["id"]): dict(row) for row in rows}
+
     def get_document_with_active_version(self, document_id: str) -> dict[str, Any]:
         """Return a document and its active version metadata."""
         document = (

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class HealthResponse(BaseModel):
@@ -60,3 +60,27 @@ class DocumentResponse(BaseModel):
 
 class DocumentListResponse(BaseModel):
     documents: list[DocumentResponse]
+
+
+class SearchRequest(BaseModel):
+    query: str = Field(min_length=1)
+    limit: int = 10
+
+
+class SearchResult(BaseModel):
+    score: float
+    text: str
+    document_id: str
+    document_version_id: str
+    chunk_id: str
+    source_path: str
+    original_filename: str
+    page_number: int | None
+    heading_path: list[str] | None
+    section_title: str | None
+    start_offset: int | None
+    end_offset: int | None
+
+
+class SearchResponse(BaseModel):
+    results: list[SearchResult]

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -64,7 +64,7 @@ class DocumentListResponse(BaseModel):
 
 class SearchRequest(BaseModel):
     query: str = Field(min_length=1)
-    limit: int = 10
+    limit: int = Field(default=10, ge=1, le=100)
 
 
 class SearchResult(BaseModel):

--- a/shared/tests/unit/test_repository.py
+++ b/shared/tests/unit/test_repository.py
@@ -196,3 +196,52 @@ def test_create_chunks_preserves_citation_metadata() -> None:
             assert chunks[0]["token_count"] == 2
     finally:
         connection.close()
+
+
+def test_get_active_chunks_by_ids_returns_only_active_version_chunks() -> None:
+    repo, connection = open_repository()
+    try:
+        with connection.begin():
+            document = repo.get_or_create_document("/watch/example.md")
+            first_version = repo.create_document_version(document["id"], "a" * 64)
+            second_version = repo.create_document_version(document["id"], "b" * 64)
+            first_chunks = repo.create_chunks(
+                document["id"],
+                first_version["id"],
+                [
+                    ChunkRecord(
+                        text="Old chunk",
+                        source_path="/watch/example.md",
+                        original_filename="example.md",
+                    )
+                ],
+            )
+            second_chunks = repo.create_chunks(
+                document["id"],
+                second_version["id"],
+                [
+                    ChunkRecord(
+                        text="Current chunk",
+                        source_path="/watch/example.md",
+                        original_filename="example.md",
+                    )
+                ],
+            )
+            repo.mark_document_version_active(second_version["id"])
+
+            chunks = repo.get_active_chunks_by_ids(
+                [first_chunks[0]["id"], second_chunks[0]["id"], "missing"]
+            )
+
+            assert list(chunks) == [second_chunks[0]["id"]]
+            assert chunks[second_chunks[0]["id"]]["text"] == "Current chunk"
+    finally:
+        connection.close()
+
+
+def test_get_active_chunks_by_ids_handles_empty_input() -> None:
+    repo, connection = open_repository()
+    try:
+        assert repo.get_active_chunks_by_ids([]) == {}
+    finally:
+        connection.close()

--- a/shared/vector_index.py
+++ b/shared/vector_index.py
@@ -24,7 +24,7 @@ class ChunkVector:
 
 @dataclass(frozen=True)
 class VectorSearchResult:
-    """Dense retrieval result with the payload IDs needed for metadata hydration."""
+    """Dense retrieval result with payload IDs needed to load chunk metadata."""
 
     chunk_id: str
     document_id: str


### PR DESCRIPTION
## Summary
- Add protected `POST /search` to embed a query, search Qdrant, and load active chunk metadata from PostgreSQL.
- Add citation-ready search schemas, bounded search limits, and active chunk lookup support.
- Harden embedding/Qdrant failure handling so backend search failures return 502 instead of 500.
- Update API/retrieval/storage docs to describe dense-only search and sparse FTS as a follow-up.

Closes #10

## Validation
- `make test.unit`
- `make lint`
- `make typecheck`
- `make test.integration`
- `mkdocs build -f docs/mkdocs.yml --strict`
- `make test.smoke`
- pre-commit hooks on commits: `ruff`, `ruff-format`, `mypy`