### PR TITLE
Add streaming SSE chat support and stream-completion for OpenAI-compatible LLM client

### DIFF
--- a/api_service/chat.py
+++ b/api_service/chat.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Protocol
 from urllib import error, request
 
@@ -112,8 +112,6 @@ class OpenAICompatibleLLMClient:
 
         return _parse_chat_completion(body)
 
-
-
     def stream_complete(
         self,
         messages: list[dict[str, str]],
@@ -150,11 +148,11 @@ class OpenAICompatibleLLMClient:
                     line = raw_line.decode("utf-8").strip()
                     if not line or not line.startswith("data:"):
                         continue
-                    payload = line.removeprefix("data:").strip()
-                    if payload == "[DONE]":
+                    data_payload = line.removeprefix("data:").strip()
+                    if data_payload == "[DONE]":
                         break
                     try:
-                        body = json.loads(payload)
+                        body = json.loads(data_payload)
                     except json.JSONDecodeError as exc:
                         raise GenerationError("LLM chat stream returned invalid JSON.") from exc
                     token = _parse_chat_stream_chunk(body)
@@ -165,6 +163,7 @@ class OpenAICompatibleLLMClient:
             raise GenerationError(f"LLM chat HTTP error: {detail}") from exc
         except error.URLError as exc:
             raise GenerationError(f"LLM chat unavailable: {exc.reason}") from exc
+
 
 class GoogleGenerateContentLLMClient:
     """HTTP client for Google AI Studio's native generateContent endpoint."""
@@ -209,7 +208,6 @@ class GoogleGenerateContentLLMClient:
             raise GenerationError(f"Google generateContent unavailable: {exc.reason}") from exc
 
         return _parse_google_generate_content(body)
-
 
     def stream_complete(
         self,

--- a/api_service/chat.py
+++ b/api_service/chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from collections.abc import Iterator
 from typing import Protocol
 from urllib import error, request
 
@@ -27,6 +28,13 @@ class LLMClient(Protocol):
         options: GenerationOptions | None = None,
     ) -> str:
         """Generate one assistant message from chat messages."""
+
+    def stream_complete(
+        self,
+        messages: list[dict[str, str]],
+        options: GenerationOptions | None = None,
+    ) -> Iterator[str]:
+        """Yield assistant message chunks from one streaming request."""
 
 
 @dataclass(frozen=True)
@@ -105,6 +113,59 @@ class OpenAICompatibleLLMClient:
         return _parse_chat_completion(body)
 
 
+
+    def stream_complete(
+        self,
+        messages: list[dict[str, str]],
+        options: GenerationOptions | None = None,
+    ) -> Iterator[str]:
+        """Yield assistant text chunks from an OpenAI-compatible stream."""
+        request_body: dict[str, object] = {
+            "model": self.model_name,
+            "messages": messages,
+            "stream": True,
+        }
+        if options is not None:
+            if options.temperature is not None:
+                request_body["temperature"] = options.temperature
+            if options.max_tokens is not None:
+                request_body["max_tokens"] = options.max_tokens
+
+        payload = json.dumps(request_body).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        req = request.Request(
+            url=self.chat_completions_url,
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                for raw_line in response:  # type: ignore[attr-defined]
+                    if not isinstance(raw_line, bytes):
+                        continue
+                    line = raw_line.decode("utf-8").strip()
+                    if not line or not line.startswith("data:"):
+                        continue
+                    payload = line.removeprefix("data:").strip()
+                    if payload == "[DONE]":
+                        break
+                    try:
+                        body = json.loads(payload)
+                    except json.JSONDecodeError as exc:
+                        raise GenerationError("LLM chat stream returned invalid JSON.") from exc
+                    token = _parse_chat_stream_chunk(body)
+                    if token:
+                        yield token
+        except error.HTTPError as exc:
+            detail = _read_http_error_detail(exc)
+            raise GenerationError(f"LLM chat HTTP error: {detail}") from exc
+        except error.URLError as exc:
+            raise GenerationError(f"LLM chat unavailable: {exc.reason}") from exc
+
 class GoogleGenerateContentLLMClient:
     """HTTP client for Google AI Studio's native generateContent endpoint."""
 
@@ -148,6 +209,28 @@ class GoogleGenerateContentLLMClient:
             raise GenerationError(f"Google generateContent unavailable: {exc.reason}") from exc
 
         return _parse_google_generate_content(body)
+
+
+    def stream_complete(
+        self,
+        messages: list[dict[str, str]],
+        options: GenerationOptions | None = None,
+    ) -> Iterator[str]:
+        raise GenerationError("Google generateContent streaming is not implemented.")
+
+
+def _parse_chat_stream_chunk(body: dict[str, object]) -> str:
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return ""
+    delta = first_choice.get("delta")
+    if not isinstance(delta, dict):
+        return ""
+    content = delta.get("content")
+    return content if isinstance(content, str) else ""
 
 
 def assess_answerability(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1,9 +1,8 @@
+import json
 from collections.abc import Iterator
 from functools import lru_cache
 from secrets import compare_digest
 from typing import Annotated
-
-import json
 
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.responses import StreamingResponse
@@ -212,15 +211,15 @@ def chat(
     if refusal_reason is not None:
         if request.stream:
             event = {
-                'type': 'done',
-                'answer': None,
-                'citations': [citation.model_dump() for citation in grounding_citations],
-                'refused': True,
-                'refusal_reason': refusal_reason,
+                "type": "done",
+                "answer": None,
+                "citations": [citation.model_dump() for citation in grounding_citations],
+                "refused": True,
+                "refusal_reason": refusal_reason,
             }
             return StreamingResponse(
                 iter([f"data: {json.dumps(event)}\n\n"]),
-                media_type='text/event-stream',
+                media_type="text/event-stream",
             )
         return ChatResponse(
             answer=None,
@@ -236,6 +235,7 @@ def chat(
     )
 
     if request.stream:
+
         def event_stream() -> Iterator[str]:
             answer_parts: list[str] = []
             try:
@@ -245,17 +245,17 @@ def chat(
             except GenerationError as error:
                 yield f"data: {json.dumps({'type': 'error', 'detail': str(error)})}\n\n"
                 return
-            final_answer = ''.join(answer_parts)
+            final_answer = "".join(answer_parts)
             done_event = {
-                'type': 'done',
-                'answer': final_answer,
-                'citations': [citation.model_dump() for citation in grounding_citations],
-                'refused': False,
-                'refusal_reason': None,
+                "type": "done",
+                "answer": final_answer,
+                "citations": [citation.model_dump() for citation in grounding_citations],
+                "refused": False,
+                "refusal_reason": None,
             }
             yield f"data: {json.dumps(done_event)}\n\n"
 
-        return StreamingResponse(event_stream(), media_type='text/event-stream')
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     try:
         answer = chat_client.complete(messages, options)

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections.abc import Iterator
 from functools import lru_cache
 from secrets import compare_digest
@@ -49,6 +50,8 @@ configure_logging()
 
 app = FastAPI(title="Personal RAG API Service")
 bearer_auth = HTTPBearer(auto_error=False)
+logger = logging.getLogger(__name__)
+CHAT_GENERATION_ERROR_DETAIL = "Chat generation failed."
 
 
 @lru_cache
@@ -182,7 +185,7 @@ def chat(
     embedding_client: Annotated[QueryEmbeddingClient, Depends(get_query_embedding_client)],
     vector_index: Annotated[VectorIndex, Depends(get_vector_index)],
     chat_client: Annotated[LLMClient, Depends(get_chat_completion_client)],
-) -> ChatResponse:
+) -> ChatResponse | StreamingResponse:
     settings = get_settings()
     retriever = SearchRetriever(
         embedding_client=embedding_client,
@@ -242,8 +245,13 @@ def chat(
                 for token in chat_client.stream_complete(messages, options):
                     answer_parts.append(token)
                     yield f"data: {json.dumps({'type': 'token', 'token': token})}\n\n"
-            except GenerationError as error:
-                yield f"data: {json.dumps({'type': 'error', 'detail': str(error)})}\n\n"
+            except GenerationError:
+                logger.exception("Chat stream generation failed.")
+                yield (
+                    f"data: "
+                    f"{json.dumps({'type': 'error', 'detail': CHAT_GENERATION_ERROR_DETAIL})}"
+                    f"\n\n"
+                )
                 return
             final_answer = "".join(answer_parts)
             done_event = {
@@ -260,9 +268,10 @@ def chat(
     try:
         answer = chat_client.complete(messages, options)
     except GenerationError as error:
+        logger.exception("Chat generation failed.")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=str(error),
+            detail=CHAT_GENERATION_ERROR_DETAIL,
         ) from error
 
     return ChatResponse(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -3,7 +3,10 @@ from functools import lru_cache
 from secrets import compare_digest
 from typing import Annotated
 
+import json
+
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoResultFound
@@ -207,6 +210,18 @@ def chat(
         ),
     )
     if refusal_reason is not None:
+        if request.stream:
+            event = {
+                'type': 'done',
+                'answer': None,
+                'citations': [citation.model_dump() for citation in grounding_citations],
+                'refused': True,
+                'refusal_reason': refusal_reason,
+            }
+            return StreamingResponse(
+                iter([f"data: {json.dumps(event)}\n\n"]),
+                media_type='text/event-stream',
+            )
         return ChatResponse(
             answer=None,
             citations=grounding_citations,
@@ -214,14 +229,36 @@ def chat(
             refusal_reason=refusal_reason,
         )
 
+    messages = build_grounded_messages(request.query, grounding_citations, grounding_config)
+    options = GenerationOptions(
+        temperature=settings.llm_temperature,
+        max_tokens=settings.llm_max_tokens,
+    )
+
+    if request.stream:
+        def event_stream() -> Iterator[str]:
+            answer_parts: list[str] = []
+            try:
+                for token in chat_client.stream_complete(messages, options):
+                    answer_parts.append(token)
+                    yield f"data: {json.dumps({'type': 'token', 'token': token})}\n\n"
+            except GenerationError as error:
+                yield f"data: {json.dumps({'type': 'error', 'detail': str(error)})}\n\n"
+                return
+            final_answer = ''.join(answer_parts)
+            done_event = {
+                'type': 'done',
+                'answer': final_answer,
+                'citations': [citation.model_dump() for citation in grounding_citations],
+                'refused': False,
+                'refusal_reason': None,
+            }
+            yield f"data: {json.dumps(done_event)}\n\n"
+
+        return StreamingResponse(event_stream(), media_type='text/event-stream')
+
     try:
-        answer = chat_client.complete(
-            build_grounded_messages(request.query, grounding_citations, grounding_config),
-            GenerationOptions(
-                temperature=settings.llm_temperature,
-                max_tokens=settings.llm_max_tokens,
-            ),
-        )
+        answer = chat_client.complete(messages, options)
     except GenerationError as error:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/api_service/tests/unit/test_chat.py
+++ b/api_service/tests/unit/test_chat.py
@@ -194,7 +194,7 @@ class FakeStreamingResponse:
     def __init__(self, lines: list[bytes]) -> None:
         self.lines = lines
 
-    def __enter__(self) -> "FakeStreamingResponse":
+    def __enter__(self) -> FakeStreamingResponse:
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -206,11 +206,13 @@ class FakeStreamingResponse:
 
 def test_openai_chat_client_streams_token_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_urlopen(*args: object, **kwargs: object) -> FakeStreamingResponse:
-        return FakeStreamingResponse([
-            b'data: {"choices":[{"delta":{"content":"Alpha "}}]}\n',
-            b'data: {"choices":[{"delta":{"content":"answer"}}]}\n',
-            b'data: [DONE]\n',
-        ])
+        return FakeStreamingResponse(
+            [
+                b'data: {"choices":[{"delta":{"content":"Alpha "}}]}\n',
+                b'data: {"choices":[{"delta":{"content":"answer"}}]}\n',
+                b"data: [DONE]\n",
+            ]
+        )
 
     monkeypatch.setattr(chat.request, "urlopen", fake_urlopen)
 

--- a/api_service/tests/unit/test_chat.py
+++ b/api_service/tests/unit/test_chat.py
@@ -188,3 +188,38 @@ def test_google_generate_content_client_rejects_missing_text(
             180,
             "secret-token",
         ).complete([{"role": "user", "content": "hello"}])
+
+
+class FakeStreamingResponse:
+    def __init__(self, lines: list[bytes]) -> None:
+        self.lines = lines
+
+    def __enter__(self) -> "FakeStreamingResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def __iter__(self):
+        return iter(self.lines)
+
+
+def test_openai_chat_client_streams_token_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(*args: object, **kwargs: object) -> FakeStreamingResponse:
+        return FakeStreamingResponse([
+            b'data: {"choices":[{"delta":{"content":"Alpha "}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"answer"}}]}\n',
+            b'data: [DONE]\n',
+        ])
+
+    monkeypatch.setattr(chat.request, "urlopen", fake_urlopen)
+
+    chunks = list(
+        OpenAICompatibleLLMClient(
+            "http://llm.example/v1/chat/completions",
+            model_name="gemma3:4b",
+            timeout_seconds=120,
+        ).stream_complete([{"role": "user", "content": "hello"}])
+    )
+
+    assert chunks == ["Alpha ", "answer"]

--- a/api_service/tests/unit/test_ingestion_document_contracts.py
+++ b/api_service/tests/unit/test_ingestion_document_contracts.py
@@ -716,7 +716,13 @@ def test_chat_stream_returns_sse_done_event(
         chunks = repository.create_chunks(
             document["id"],
             version["id"],
-            [ChunkRecord(text="Alpha content", source_path="/watch/example.md", original_filename="example.md")],
+            [
+                ChunkRecord(
+                    text="Alpha content",
+                    source_path="/watch/example.md",
+                    original_filename="example.md",
+                )
+            ],
         )
         repository.mark_document_version_active(version["id"])
 
@@ -732,10 +738,10 @@ def test_chat_stream_returns_sse_done_event(
     app.dependency_overrides[get_vector_index] = lambda: vector_index
     app.dependency_overrides[get_chat_completion_client] = lambda: chat_client
 
-    response = client.post('/chat', json={"query": "alpha", "stream": True}, headers=auth_headers())
+    response = client.post("/chat", json={"query": "alpha", "stream": True}, headers=auth_headers())
 
     assert response.status_code == 200
-    assert response.headers['content-type'].startswith('text/event-stream')
+    assert response.headers["content-type"].startswith("text/event-stream")
     assert '"type": "token"' in response.text
     assert '"type": "done"' in response.text
     assert '"answer": "Alpha answer"' in response.text
@@ -749,10 +755,10 @@ def test_chat_stream_refusal_returns_single_done_event(client: TestClient) -> No
     app.dependency_overrides[get_vector_index] = lambda: vector_index
     app.dependency_overrides[get_chat_completion_client] = lambda: chat_client
 
-    response = client.post('/chat', json={"query": "alpha", "stream": True}, headers=auth_headers())
+    response = client.post("/chat", json={"query": "alpha", "stream": True}, headers=auth_headers())
 
     assert response.status_code == 200
-    assert response.headers['content-type'].startswith('text/event-stream')
+    assert response.headers["content-type"].startswith("text/event-stream")
     assert '"refused": true' in response.text
-    assert 'Retrieved evidence is insufficient to answer reliably.' in response.text
+    assert "Retrieved evidence is insufficient to answer reliably." in response.text
     assert chat_client.stream_messages == []

--- a/api_service/tests/unit/test_ingestion_document_contracts.py
+++ b/api_service/tests/unit/test_ingestion_document_contracts.py
@@ -583,7 +583,7 @@ def test_chat_returns_bad_gateway_for_generation_failure(
     )
 
     assert response.status_code == 502
-    assert response.json()["detail"] == "LLM chat response missing choices."
+    assert response.json()["detail"] == "Chat generation failed."
 
 
 def test_search_returns_empty_results_when_vector_search_is_empty(client: TestClient) -> None:
@@ -745,6 +745,55 @@ def test_chat_stream_returns_sse_done_event(
     assert '"type": "token"' in response.text
     assert '"type": "done"' in response.text
     assert '"answer": "Alpha answer"' in response.text
+
+
+def test_chat_stream_returns_sanitized_error_event(
+    client: TestClient,
+    engine: Engine,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+    chat_client = FakeChatCompletionClient()
+    chat_client.error = GenerationError("LLM chat response missing choices.")
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document("/watch/example.md")
+        version = repository.create_document_version(document["id"], "a" * 64)
+        chunks = repository.create_chunks(
+            document["id"],
+            version["id"],
+            [
+                ChunkRecord(
+                    text="Alpha content",
+                    source_path="/watch/example.md",
+                    original_filename="example.md",
+                )
+            ],
+        )
+        repository.mark_document_version_active(version["id"])
+
+    vector_index.results = [
+        VectorSearchResult(
+            chunk_id=chunks[0]["id"],
+            document_id=document["id"],
+            document_version_id=version["id"],
+            score=0.92,
+        )
+    ]
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+    app.dependency_overrides[get_chat_completion_client] = lambda: chat_client
+
+    response = client.post("/chat", json={"query": "alpha", "stream": True}, headers=auth_headers())
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert '"type": "error"' in response.text
+    assert '"detail": "Chat generation failed."' in response.text
+    assert "LLM chat response missing choices." not in response.text
+    assert "LLM chat response missing choices." in caplog.text
 
 
 def test_chat_stream_refusal_returns_single_done_event(client: TestClient) -> None:

--- a/api_service/tests/unit/test_ingestion_document_contracts.py
+++ b/api_service/tests/unit/test_ingestion_document_contracts.py
@@ -99,6 +99,7 @@ class FakeVectorIndex:
 class FakeChatCompletionClient:
     def __init__(self) -> None:
         self.messages: list[list[dict[str, str]]] = []
+        self.stream_messages: list[list[dict[str, str]]] = []
         self.error: GenerationError | None = None
 
     def complete(self, messages: list[dict[str, str]], options: object | None = None) -> str:
@@ -106,6 +107,13 @@ class FakeChatCompletionClient:
         if self.error is not None:
             raise self.error
         return "Alpha is answered from the retrieved context [1]."
+
+    def stream_complete(self, messages: list[dict[str, str]], options: object | None = None):
+        self.stream_messages.append(messages)
+        if self.error is not None:
+            raise self.error
+        yield "Alpha "
+        yield "answer"
 
 
 def test_protected_endpoints_require_api_key(client: TestClient) -> None:
@@ -691,3 +699,60 @@ def test_search_returns_bad_gateway_for_vector_index_failure(client: TestClient)
 
     assert response.status_code == 502
     assert response.json()["detail"] == "Vector index search failed."
+
+
+def test_chat_stream_returns_sse_done_event(
+    client: TestClient,
+    engine: Engine,
+) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+    chat_client = FakeChatCompletionClient()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = repository.get_or_create_document("/watch/example.md")
+        version = repository.create_document_version(document["id"], "a" * 64)
+        chunks = repository.create_chunks(
+            document["id"],
+            version["id"],
+            [ChunkRecord(text="Alpha content", source_path="/watch/example.md", original_filename="example.md")],
+        )
+        repository.mark_document_version_active(version["id"])
+
+    vector_index.results = [
+        VectorSearchResult(
+            chunk_id=chunks[0]["id"],
+            document_id=document["id"],
+            document_version_id=version["id"],
+            score=0.92,
+        )
+    ]
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+    app.dependency_overrides[get_chat_completion_client] = lambda: chat_client
+
+    response = client.post('/chat', json={"query": "alpha", "stream": True}, headers=auth_headers())
+
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/event-stream')
+    assert '"type": "token"' in response.text
+    assert '"type": "done"' in response.text
+    assert '"answer": "Alpha answer"' in response.text
+
+
+def test_chat_stream_refusal_returns_single_done_event(client: TestClient) -> None:
+    embedding_client = FakeQueryEmbeddingClient()
+    vector_index = FakeVectorIndex()
+    chat_client = FakeChatCompletionClient()
+    app.dependency_overrides[get_query_embedding_client] = lambda: embedding_client
+    app.dependency_overrides[get_vector_index] = lambda: vector_index
+    app.dependency_overrides[get_chat_completion_client] = lambda: chat_client
+
+    response = client.post('/chat', json={"query": "alpha", "stream": True}, headers=auth_headers())
+
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/event-stream')
+    assert '"refused": true' in response.text
+    assert 'Retrieved evidence is insufficient to answer reliably.' in response.text
+    assert chat_client.stream_messages == []

--- a/shared/schemas.py
+++ b/shared/schemas.py
@@ -91,7 +91,7 @@ class SearchResponse(BaseModel):
 
 
 class ChatRequest(QueryLimitRequest):
-    pass
+    stream: bool = False
 
 
 class ChatResponse(BaseModel):


### PR DESCRIPTION
### **User description**
### Motivation
- Support server-sent event (SSE) streaming from the chat endpoint so clients can receive incremental tokens and a final done event.
- Provide a streaming interface on LLM clients to consume tokenized streaming responses from OpenAI-compatible endpoints.

### Description
- Add `stream_complete` to the `LLMClient` `Protocol` and implement it on `OpenAICompatibleLLMClient` to parse SSE-style `data:` lines, yield token chunks, and surface HTTP/URL errors as `GenerationError`.
- Add a `stream_complete` stub on `GoogleGenerateContentLLMClient` that raises `GenerationError` because streaming is not implemented for that provider, and add `_parse_chat_stream_chunk` helper to extract token content from stream payloads.
- Extend the `/chat` handler to accept `stream` on `ChatRequest` and return a `StreamingResponse` with typed SSE messages for token events and a final `done` event, and return a single `done` SSE event for refused responses.
- Update imports and use `GenerationOptions` and `build_grounded_messages` to drive both streaming and non-streaming code paths.
- Add tests and test helpers to validate streaming behavior, including `test_openai_chat_client_streams_token_chunks`, `test_chat_stream_returns_sse_done_event`, and `test_chat_stream_refusal_returns_single_done_event`, and adjust test fakes to support `stream_complete`.

### Testing
- Ran unit tests including `test_openai_chat_client_streams_token_chunks`, `test_chat_stream_returns_sse_done_event`, and `test_chat_stream_refusal_returns_single_done_event` under `pytest` and all new and existing tests succeeded.
- Exercised the OpenAI-compatible streaming parser with a fake streaming response that yielded expected token chunks in `test_openai_chat_client_streams_token_chunks`, which passed.
- Verified SSE output from the `/chat` endpoint for both normal and refusal flows via `test_chat_stream_returns_sse_done_event` and `test_chat_stream_refusal_returns_single_done_event`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f260d875dc8322b04718f76ef5cb5c)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `stream_complete` to `LLMClient` protocol.

- Implement streaming for OpenAI-compatible clients.

- Extend `/chat` endpoint for SSE streaming.

- Add comprehensive tests for streaming chat.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client Request (stream=True)"] --> ChatEndpoint["/chat Endpoint"];
  ChatEndpoint -- "Calls stream_complete" --> OpenAIClient["OpenAICompatibleLLMClient"];
  OpenAIClient -- "Yields token chunks" --> ChatEndpoint;
  ChatEndpoint -- "Streams SSE events" --> Client;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.py</strong><dd><code>Implement streaming completion for LLM clients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/chat.py

<ul><li>Added <code>Iterator</code> to imports for type hinting streaming responses.<br> <li> Introduced <code>stream_complete</code> method to the <code>LLMClient</code> Protocol for <br>yielding assistant message chunks.<br> <li> Implemented <code>stream_complete</code> in <code>OpenAICompatibleLLMClient</code> to handle SSE <br>streaming, parse <code>data:</code> lines, extract tokens, and manage HTTP/URL <br>errors.<br> <li> Added a <code>stream_complete</code> stub to <code>GoogleGenerateContentLLMClient</code> that <br>raises <code>GenerationError</code> as streaming is not yet supported.<br> <li> Introduced <code>_parse_chat_stream_chunk</code> helper to extract content from <br>streaming JSON payloads.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/31/files#diff-1019dd3aab6617a3935d85b5cbfa751d63c3406dad164edb4c54ed924f25381f">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Enable SSE streaming responses for the /chat endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/main.py

<ul><li>Imported <code>json</code> and <code>StreamingResponse</code> to support SSE streaming.<br> <li> Modified the <code>/chat</code> endpoint to check for <code>request.stream</code> and return a <br><code>StreamingResponse</code> for streaming requests.<br> <li> Implemented an <code>event_stream</code> generator function to yield <code>token</code>, <code>error</code>, <br>and <code>done</code> SSE events.<br> <li> Handled refusal scenarios by returning a single <code>done</code> SSE event with <br>refusal details.<br> <li> Updated the chat logic to use <code>chat_client.stream_complete</code> for <br>streaming and <code>chat_client.complete</code> for non-streaming requests.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/31/files#diff-992287f42f167ab442781b4871fdd4be342978c1bfe7820972abcca09773a764">+44/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schemas.py</strong><dd><code>Add stream parameter to ChatRequest schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

shared/schemas.py

- Added a `stream: bool = False` field to the `ChatRequest` schema.


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/31/files#diff-b74bf422f142dd839ff610879d248a89c7a9db1f02f0468d56545054ec85b35a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chat.py</strong><dd><code>Add unit tests for OpenAI streaming client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/tests/unit/test_chat.py

<ul><li>Added <code>FakeStreamingResponse</code> class to simulate HTTP streaming responses <br>for testing.<br> <li> Implemented <code>test_openai_chat_client_streams_token_chunks</code> to verify <br>that the <code>OpenAICompatibleLLMClient</code> correctly parses and yields token <br>chunks from a fake SSE stream.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/31/files#diff-b80d11a61fbdc2a3727aec370f88d11439e5e0975ff430b611dfb08f85c2b454">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ingestion_document_contracts.py</strong><dd><code>Add integration tests for streaming chat endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/tests/unit/test_ingestion_document_contracts.py

<ul><li>Added <code>stream_messages</code> attribute to <code>FakeChatCompletionClient</code> to record <br>messages sent to the streaming method.<br> <li> Implemented a <code>stream_complete</code> method in <code>FakeChatCompletionClient</code> to <br>simulate yielding token chunks for testing.<br> <li> Added <code>test_chat_stream_returns_sse_done_event</code> to verify successful <br>streaming chat responses, including <code>token</code> and <code>done</code> events.<br> <li> Added <code>test_chat_stream_refusal_returns_single_done_event</code> to confirm <br>that refusal scenarios return a single <code>done</code> SSE event without calling <br>the LLM client's streaming method.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/31/files#diff-0bceacc655c3261fac350d5c3ed772f84592f4d4d7e4386ed8488f3975f74cad">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

