### PR TITLE
[codex] Implement watch-root deletion reconciliation

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -32,6 +32,13 @@ from api_service.retrieval import (
     VectorIndex,
 )
 from shared.config import get_settings, parse_path_list
+from shared.file_cleanup import (
+    delete_file_if_present,
+    delete_unique_files,
+    validate_file_cleanup_targets,
+    validate_path_under_root,
+    validate_path_under_roots,
+)
 from shared.logging_config import configure_logging
 from shared.repository import MetadataRepository, create_metadata_engine
 from shared.schemas import (
@@ -198,12 +205,12 @@ def delete_document(
     document = deletion_target["document"]
     source_path = str(document["source_path"])
     try:
-        source_file = _validate_path_under_roots(source_path, parse_path_list(settings.watch_roots))
+        source_file = validate_path_under_roots(source_path, parse_path_list(settings.watch_roots))
         managed_files = [
-            _validate_path_under_root(path, Path(settings.document_store_path).expanduser())
+            validate_path_under_root(path, Path(settings.document_store_path).expanduser())
             for path in deletion_target["managed_store_paths"]
         ]
-        _validate_file_cleanup_targets([source_file, *managed_files])
+        validate_file_cleanup_targets([source_file, *managed_files])
     except ValueError as error:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -220,8 +227,8 @@ def delete_document(
         ) from error
 
     try:
-        source_file_deleted = _delete_file_if_present(source_file)
-        managed_store_paths_deleted = _delete_unique_files(managed_files)
+        source_file_deleted = delete_file_if_present(source_file)
+        managed_store_paths_deleted = delete_unique_files(managed_files)
     except ValueError as error:
         logger.exception("Document deletion validation failed during local cleanup.")
         raise HTTPException(
@@ -247,52 +254,6 @@ def delete_document(
         source_file_deleted=source_file_deleted,
         managed_store_paths_deleted=managed_store_paths_deleted,
     )
-
-
-def _validate_path_under_roots(path: str, roots: tuple[Path, ...]) -> Path:
-    if not roots:
-        raise ValueError("WATCH_ROOTS must contain at least one path for document deletion.")
-    for root in roots:
-        try:
-            return _validate_path_under_root(path, root)
-        except ValueError:
-            continue
-    raise ValueError(f"Path is outside configured watch roots: {path}")
-
-
-def _validate_path_under_root(path: str | Path, root: Path) -> Path:
-    resolved_path = Path(path).expanduser().resolve(strict=False)
-    resolved_root = root.expanduser().resolve(strict=False)
-    try:
-        resolved_path.relative_to(resolved_root)
-    except ValueError as error:
-        raise ValueError(f"Path is outside configured root: {path}") from error
-    return resolved_path
-
-
-def _delete_file_if_present(path: Path) -> bool:
-    if not path.exists():
-        return False
-    path.unlink()
-    return True
-
-
-def _validate_file_cleanup_targets(paths: list[Path]) -> None:
-    for path in paths:
-        if path.exists() and not path.is_file():
-            raise ValueError(f"Deletion target is not a file: {path}")
-
-
-def _delete_unique_files(paths: list[Path]) -> list[str]:
-    deleted: list[str] = []
-    seen: set[Path] = set()
-    for path in paths:
-        if path in seen:
-            continue
-        seen.add(path)
-        if _delete_file_if_present(path):
-            deleted.append(str(path))
-    return deleted
 
 
 @app.post(

--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -76,7 +76,7 @@ nightly cron or systemd timer can call:
 ```bash
 curl -fsS -X POST \
   -H "Authorization: Bearer ${RAG_API_KEY}" \
-  "${RAG_API_URL}/ingest"
+  "${RAG_API_URL}/ingest" && \
 python -m ingestion_worker.worker --fail-on-error
 ```
 

--- a/ingestion_worker/README.md
+++ b/ingestion_worker/README.md
@@ -7,7 +7,9 @@ The `ingestion-worker` owns background document processing.
 The worker claims ingestion jobs, scans configured watch roots, reconciles the index against the filesystem source of truth, parses supported files, chunks text, calls `embedding-service`, and writes metadata/vectors/document copies.
 
 The current implementation exposes the health endpoint plus a one-shot worker
-pipeline for processing pending PostgreSQL ingestion jobs.
+pipeline for processing pending PostgreSQL ingestion jobs. Scheduled operation is
+handled by external automation, such as cron or systemd timers, creating full-scan
+jobs and invoking the one-shot worker.
 
 ## Responsibilities
 
@@ -25,9 +27,13 @@ pipeline for processing pending PostgreSQL ingestion jobs.
 - Preserve citation metadata on chunks: source path, filename, Markdown heading path, PDF page number, section title, and character offsets where available.
 - Claim pending ingestion jobs with PostgreSQL row locking.
 - Process full-scan and single-path ingestion jobs once per worker invocation.
+- Reconcile missing source files during full-scan jobs after watch-root health
+  checks.
 - Call `embedding-service` for batch document embeddings.
 - Persist documents, versions, chunks, job state, and embedding metadata in PostgreSQL.
 - Upsert chunk vectors into Qdrant after chunk metadata is persisted.
+- Delete Qdrant vectors, managed document-store copies, and metadata for active
+  documents whose source files are missing under healthy watch roots.
 - Skip duplicate raw-byte content hashes without creating another document version.
 
 ## API Contract
@@ -63,6 +69,21 @@ loop or scheduler. Pass `--fail-on-error` when automation should receive a
 non-zero exit code for a claimed job that ends in `failed`; an idle run with no
 pending job still exits successfully.
 
+For scheduled reconciliation, run external automation that creates a full-scan
+job through `api-service` and then invokes the one-shot worker. For example, a
+nightly cron or systemd timer can call:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer ${RAG_API_KEY}" \
+  "${RAG_API_URL}/ingest"
+python -m ingestion_worker.worker --fail-on-error
+```
+
+The worker intentionally remains one-shot so deployment owners can choose cron,
+systemd timers, Docker scheduling, or another external scheduler without adding
+an in-process scheduler dependency.
+
 Job status progresses through the persisted ADR-005 lifecycle states. A document
 version is marked active only after Qdrant upsert succeeds. Hard failures mark
 the job failed with an error message and mark any in-progress document/version
@@ -82,8 +103,10 @@ failed for inspection.
 
 Scans skip dot-prefixed files and directories by default. Symlinks are followed,
 and resolved directories/files are tracked so cycles and duplicate discoveries do
-not repeat work. Unhealthy roots are reported in the scan result; deletion
-reconciliation is intentionally out of scope for this module slice.
+not repeat work. Unhealthy roots are reported in the scan result. Full-scan jobs
+continue processing healthy roots while skipping deletion reconciliation for
+documents under unhealthy roots. Single-path jobs do not run deletion
+reconciliation.
 
 Managed-copy hashes must be 64-character SHA-256 hex digests. Hash values are
 normalized to lowercase before path construction, existing managed copies are

--- a/ingestion_worker/pipeline.py
+++ b/ingestion_worker/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import socket
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,6 +13,7 @@ from sqlalchemy.engine import Engine
 
 from ingestion_worker.chunking import DocumentChunk, StructureAwareChunker
 from ingestion_worker.filesystem import (
+    UnhealthyWatchRoot,
     compute_sha256,
     copy_to_managed_store,
     parse_watch_roots,
@@ -21,6 +23,8 @@ from ingestion_worker.parsing import ParserRegistry, default_parser_registry
 from shared.config import AppSettings, get_settings
 from shared.repository import ChunkRecord, MetadataRepository, create_metadata_engine
 from shared.vector_index import ChunkVector, QdrantVectorIndex
+
+logger = logging.getLogger(__name__)
 
 
 class IngestionPipelineError(RuntimeError):
@@ -94,6 +98,9 @@ class VectorIndex(Protocol):
 
     def upsert_chunks(self, chunks: list[ChunkVector]) -> None:
         """Persist chunk vectors to the vector index."""
+
+    def delete_by_document_id(self, document_id: str) -> None:
+        """Remove all vectors belonging to one logical document."""
 
 
 class HttpEmbeddingClient:
@@ -256,7 +263,60 @@ def _process_claimed_job(
     parser_registry: ParserRegistry,
     chunker: StructureAwareChunker,
 ) -> int:
-    source_paths = _resolve_job_source_paths(job, settings, parser_registry)
+    requested_path = job.get("requested_path")
+    if requested_path:
+        source_paths = [
+            _validate_requested_path(Path(str(requested_path)).expanduser(), parser_registry)
+        ]
+        return _process_source_paths(
+            repository=repository,
+            job=job,
+            source_paths=source_paths,
+            settings=settings,
+            context=context,
+            parser_registry=parser_registry,
+            chunker=chunker,
+        )
+
+    watch_roots = parse_watch_roots(settings.watch_roots)
+    scan_result = scan_watch_roots(watch_roots, parser_registry)
+    for unhealthy_root in scan_result.unhealthy_roots:
+        logger.warning(
+            "Skipping deletion reconciliation for unhealthy watch root %s: %s",
+            unhealthy_root.root_path,
+            unhealthy_root.reason,
+        )
+    processed_items = _reconcile_missing_source_files(
+        repository=repository,
+        settings=settings,
+        vector_index=context.vector_index,
+        healthy_roots=_healthy_roots(watch_roots, scan_result.unhealthy_roots),
+    )
+    if processed_items:
+        repository.update_ingestion_job(str(job["id"]), "running", processed_items)
+
+    return processed_items + _process_source_paths(
+        repository=repository,
+        job=job,
+        source_paths=[discovered.source_path for discovered in scan_result.files],
+        settings=settings,
+        context=context,
+        parser_registry=parser_registry,
+        chunker=chunker,
+        initial_processed_items=processed_items,
+    )
+
+
+def _process_source_paths(
+    repository: MetadataRepository,
+    job: dict[str, object],
+    source_paths: list[Path],
+    settings: AppSettings,
+    context: IngestionJobContext,
+    parser_registry: ParserRegistry,
+    chunker: StructureAwareChunker,
+    initial_processed_items: int = 0,
+) -> int:
     processed_items = 0
     for source_path in source_paths:
         _process_source_path(
@@ -269,26 +329,112 @@ def _process_claimed_job(
             chunker=chunker,
         )
         processed_items += 1
-        repository.update_ingestion_job(str(job["id"]), "running", processed_items)
+        repository.update_ingestion_job(
+            str(job["id"]),
+            "running",
+            initial_processed_items + processed_items,
+        )
     return processed_items
 
 
-def _resolve_job_source_paths(
-    job: dict[str, object],
+def _reconcile_missing_source_files(
+    repository: MetadataRepository,
     settings: AppSettings,
-    parser_registry: ParserRegistry,
-) -> list[Path]:
-    requested_path = job.get("requested_path")
-    if requested_path:
-        return [_validate_requested_path(Path(str(requested_path)).expanduser(), parser_registry)]
+    vector_index: VectorIndex,
+    healthy_roots: tuple[Path, ...],
+) -> int:
+    if not healthy_roots:
+        return 0
 
-    scan_result = scan_watch_roots(parse_watch_roots(settings.watch_roots), parser_registry)
-    if scan_result.unhealthy_roots:
-        unhealthy = scan_result.unhealthy_roots[0]
-        raise IngestionPipelineError(
-            f"Unhealthy watch root {unhealthy.root_path}: {unhealthy.reason}"
-        )
-    return [discovered.source_path for discovered in scan_result.files]
+    reconciled = 0
+    document_store_root = Path(settings.document_store_path).expanduser()
+    for row in repository.list_documents():
+        document = row["document"]
+        active_version = row["active_version"]
+        if active_version is None or document["state"] != "active":
+            continue
+
+        source_path = Path(str(document["source_path"])).expanduser()
+        if not _is_path_under_roots(source_path, healthy_roots):
+            continue
+        if source_path.exists():
+            continue
+
+        deletion_target = repository.get_document_deletion_target(str(document["id"]))
+        if deletion_target is None:
+            continue
+
+        managed_files = [
+            _validate_path_under_root(path, document_store_root)
+            for path in deletion_target["managed_store_paths"]
+        ]
+        _validate_file_cleanup_targets(managed_files)
+
+        vector_index.delete_by_document_id(str(document["id"]))
+        _delete_unique_files(managed_files)
+        repository.delete_document(str(document["id"]))
+        reconciled += 1
+
+    return reconciled
+
+
+def _healthy_roots(
+    roots: tuple[Path, ...],
+    unhealthy_roots: tuple[UnhealthyWatchRoot, ...],
+) -> tuple[Path, ...]:
+    unhealthy = {_resolve_path(root.root_path) for root in unhealthy_roots}
+    return tuple(root for root in roots if _resolve_path(root) not in unhealthy)
+
+
+def _is_path_under_roots(path: Path, roots: tuple[Path, ...]) -> bool:
+    return any(_is_path_under_root(path, root) for root in roots)
+
+
+def _is_path_under_root(path: Path, root: Path) -> bool:
+    try:
+        _validate_path_under_root(path, root)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_path_under_root(path: str | Path, root: Path) -> Path:
+    resolved_path = _resolve_path(Path(path))
+    resolved_root = _resolve_path(root)
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as error:
+        raise ValueError(f"Path is outside configured root: {path}") from error
+    return resolved_path
+
+
+def _resolve_path(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _validate_file_cleanup_targets(paths: list[Path]) -> None:
+    for path in paths:
+        if path.exists() and not path.is_file():
+            raise ValueError(f"Deletion target is not a file: {path}")
+
+
+def _delete_file_if_present(path: Path) -> bool:
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def _delete_unique_files(paths: list[Path]) -> list[str]:
+    deleted: list[str] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        if _delete_file_if_present(path):
+            deleted.append(str(path))
+    return deleted
 
 
 def _validate_requested_path(source_path: Path, parser_registry: ParserRegistry) -> Path:

--- a/ingestion_worker/pipeline.py
+++ b/ingestion_worker/pipeline.py
@@ -21,6 +21,13 @@ from ingestion_worker.filesystem import (
 )
 from ingestion_worker.parsing import ParserRegistry, default_parser_registry
 from shared.config import AppSettings, get_settings
+from shared.file_cleanup import (
+    delete_unique_files,
+    is_path_under_roots,
+    resolve_path,
+    validate_file_cleanup_targets,
+    validate_path_under_root,
+)
 from shared.repository import ChunkRecord, MetadataRepository, create_metadata_engine
 from shared.vector_index import ChunkVector, QdrantVectorIndex
 
@@ -355,7 +362,7 @@ def _reconcile_missing_source_files(
             continue
 
         source_path = Path(str(document["source_path"])).expanduser()
-        if not _is_path_under_roots(source_path, healthy_roots):
+        if not is_path_under_roots(source_path, healthy_roots):
             continue
         if source_path.exists():
             continue
@@ -365,13 +372,13 @@ def _reconcile_missing_source_files(
             continue
 
         managed_files = [
-            _validate_path_under_root(path, document_store_root)
+            validate_path_under_root(path, document_store_root)
             for path in deletion_target["managed_store_paths"]
         ]
-        _validate_file_cleanup_targets(managed_files)
+        validate_file_cleanup_targets(managed_files)
 
         vector_index.delete_by_document_id(str(document["id"]))
-        _delete_unique_files(managed_files)
+        delete_unique_files(managed_files)
         repository.delete_document(str(document["id"]))
         reconciled += 1
 
@@ -382,59 +389,8 @@ def _healthy_roots(
     roots: tuple[Path, ...],
     unhealthy_roots: tuple[UnhealthyWatchRoot, ...],
 ) -> tuple[Path, ...]:
-    unhealthy = {_resolve_path(root.root_path) for root in unhealthy_roots}
-    return tuple(root for root in roots if _resolve_path(root) not in unhealthy)
-
-
-def _is_path_under_roots(path: Path, roots: tuple[Path, ...]) -> bool:
-    return any(_is_path_under_root(path, root) for root in roots)
-
-
-def _is_path_under_root(path: Path, root: Path) -> bool:
-    try:
-        _validate_path_under_root(path, root)
-    except ValueError:
-        return False
-    return True
-
-
-def _validate_path_under_root(path: str | Path, root: Path) -> Path:
-    resolved_path = _resolve_path(Path(path))
-    resolved_root = _resolve_path(root)
-    try:
-        resolved_path.relative_to(resolved_root)
-    except ValueError as error:
-        raise ValueError(f"Path is outside configured root: {path}") from error
-    return resolved_path
-
-
-def _resolve_path(path: Path) -> Path:
-    return path.expanduser().resolve(strict=False)
-
-
-def _validate_file_cleanup_targets(paths: list[Path]) -> None:
-    for path in paths:
-        if path.exists() and not path.is_file():
-            raise ValueError(f"Deletion target is not a file: {path}")
-
-
-def _delete_file_if_present(path: Path) -> bool:
-    if not path.exists():
-        return False
-    path.unlink()
-    return True
-
-
-def _delete_unique_files(paths: list[Path]) -> list[str]:
-    deleted: list[str] = []
-    seen: set[Path] = set()
-    for path in paths:
-        if path in seen:
-            continue
-        seen.add(path)
-        if _delete_file_if_present(path):
-            deleted.append(str(path))
-    return deleted
+    unhealthy = {resolve_path(root.root_path) for root in unhealthy_roots}
+    return tuple(root for root in roots if resolve_path(root) not in unhealthy)
 
 
 def _validate_requested_path(source_path: Path, parser_registry: ParserRegistry) -> Path:

--- a/ingestion_worker/tests/unit/test_pipeline.py
+++ b/ingestion_worker/tests/unit/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -313,7 +314,7 @@ def test_full_scan_processes_healthy_root_when_another_root_is_unhealthy(
     missing_source = missing_root / "missing.md"
     managed_path = document_store / "aa" / "managed.md"
     settings = make_settings(tmp_path)
-    settings.watch_roots = f"{healthy_root}:{missing_root}"
+    settings.watch_roots = os.pathsep.join((str(healthy_root), str(missing_root)))
     embedding_client = FakeEmbeddingClient()
     vector_index = FakeVectorIndex()
 

--- a/ingestion_worker/tests/unit/test_pipeline.py
+++ b/ingestion_worker/tests/unit/test_pipeline.py
@@ -14,7 +14,7 @@ from ingestion_worker.pipeline import (
 )
 from shared.config import AppSettings
 from shared.db import chunks, metadata
-from shared.repository import MetadataRepository
+from shared.repository import ChunkRecord, MetadataRepository
 from shared.vector_index import ChunkVector
 
 
@@ -41,6 +41,7 @@ class FakeVectorIndex:
         self.dimension: int | None = None
         self.ensure_calls: list[int] = []
         self.vectors: list[ChunkVector] = []
+        self.deleted_document_ids: list[str] = []
 
     def ensure_collection(self, dimension: int) -> None:
         self.dimension = dimension
@@ -48,6 +49,9 @@ class FakeVectorIndex:
 
     def upsert_chunks(self, chunks: list[ChunkVector]) -> None:
         self.vectors.extend(chunks)
+
+    def delete_by_document_id(self, document_id: str) -> None:
+        self.deleted_document_ids.append(document_id)
 
 
 class RaisingParser(BaseDocumentParser):
@@ -72,6 +76,31 @@ def make_engine():
     engine = create_engine("sqlite+pysqlite:///:memory:")
     metadata.create_all(engine)
     return engine
+
+
+def create_active_document(
+    repository: MetadataRepository,
+    source_path: Path,
+    managed_path: Path,
+    content_hash: str,
+) -> dict[str, object]:
+    managed_path.parent.mkdir(parents=True, exist_ok=True)
+    managed_path.write_text("managed content", encoding="utf-8")
+    document = repository.get_or_create_document(str(source_path))
+    version = repository.create_document_version(document["id"], content_hash, str(managed_path))
+    repository.create_chunks(
+        document["id"],
+        version["id"],
+        [
+            ChunkRecord(
+                text="Chunk text",
+                source_path=str(source_path),
+                original_filename=source_path.name,
+            )
+        ],
+    )
+    repository.mark_document_version_active(version["id"])
+    return document
 
 
 def test_process_next_job_returns_false_when_no_job(tmp_path: Path) -> None:
@@ -198,6 +227,172 @@ def test_process_next_job_full_scan_caches_model_info_and_collection_setup(
     assert embedding_client.embedded_texts == ["Alpha content.", "Beta content."]
     assert vector_index.ensure_calls == [3]
     assert len(vector_index.vectors) == 2
+
+
+def test_full_scan_reconciles_missing_source_file_under_healthy_root(tmp_path: Path) -> None:
+    engine = make_engine()
+    watch_root = tmp_path / "watch"
+    watch_root.mkdir()
+    document_store = tmp_path / "documents"
+    source_path = watch_root / "missing.md"
+    managed_path = document_store / "aa" / "managed.md"
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = create_active_document(repository, source_path, managed_path, "a" * 64)
+        job = repository.create_ingestion_job()
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+        persisted_chunks = connection.execute(select(chunks)).mappings().all()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 1
+    assert documents == []
+    assert persisted_chunks == []
+    assert not managed_path.exists()
+    assert vector_index.deleted_document_ids == [document["id"]]
+
+
+def test_full_scan_skips_deletion_reconciliation_for_unhealthy_root(tmp_path: Path) -> None:
+    engine = make_engine()
+    missing_root = tmp_path / "missing-root"
+    document_store = tmp_path / "documents"
+    source_path = missing_root / "missing.md"
+    managed_path = document_store / "aa" / "managed.md"
+    settings = make_settings(tmp_path)
+    settings.watch_roots = str(missing_root)
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        document = create_active_document(repository, source_path, managed_path, "a" * 64)
+        job = repository.create_ingestion_job()
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=settings,
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 0
+    assert documents[0]["document"]["id"] == document["id"]
+    assert managed_path.exists()
+    assert vector_index.deleted_document_ids == []
+
+
+def test_full_scan_processes_healthy_root_when_another_root_is_unhealthy(
+    tmp_path: Path,
+) -> None:
+    engine = make_engine()
+    healthy_root = tmp_path / "healthy"
+    healthy_root.mkdir()
+    new_source = healthy_root / "new.md"
+    new_source.write_text("# New\n\nHealthy content.", encoding="utf-8")
+    missing_root = tmp_path / "missing-root"
+    document_store = tmp_path / "documents"
+    missing_source = missing_root / "missing.md"
+    managed_path = document_store / "aa" / "managed.md"
+    settings = make_settings(tmp_path)
+    settings.watch_roots = f"{healthy_root}:{missing_root}"
+    embedding_client = FakeEmbeddingClient()
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        skipped_document = create_active_document(
+            repository,
+            missing_source,
+            managed_path,
+            "a" * 64,
+        )
+        job = repository.create_ingestion_job()
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=settings,
+        engine=engine,
+        embedding_client=embedding_client,
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 1
+    assert {row["document"]["source_path"] for row in documents} == {
+        str(missing_source),
+        str(new_source),
+    }
+    assert documents[0]["document"]["id"] == skipped_document["id"]
+    assert managed_path.exists()
+    assert embedding_client.embedded_texts == ["Healthy content."]
+    assert vector_index.deleted_document_ids == []
+    assert len(vector_index.vectors) == 1
+
+
+def test_single_path_job_does_not_run_deletion_reconciliation(tmp_path: Path) -> None:
+    engine = make_engine()
+    watch_root = tmp_path / "watch"
+    watch_root.mkdir()
+    requested_source = watch_root / "requested.md"
+    requested_source.write_text("# Requested\n\nRequested content.", encoding="utf-8")
+    missing_source = watch_root / "missing.md"
+    document_store = tmp_path / "documents"
+    managed_path = document_store / "aa" / "managed.md"
+    vector_index = FakeVectorIndex()
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        missing_document = create_active_document(
+            repository,
+            missing_source,
+            managed_path,
+            "a" * 64,
+        )
+        job = repository.create_ingestion_job(str(requested_source))
+
+    process_next_job(
+        worker_id="unit-worker",
+        settings=make_settings(tmp_path),
+        engine=engine,
+        embedding_client=FakeEmbeddingClient(),
+        vector_index=vector_index,
+    )
+
+    with engine.begin() as connection:
+        repository = MetadataRepository(connection)
+        updated_job = repository.get_ingestion_job(job["id"])
+        documents = repository.list_documents()
+
+    assert updated_job["status"] == "active"
+    assert updated_job["processed_items"] == 1
+    assert str(missing_source) in {row["document"]["source_path"] for row in documents}
+    assert managed_path.exists()
+    assert vector_index.deleted_document_ids == []
+    assert missing_document["id"] in {row["document"]["id"] for row in documents}
 
 
 def test_process_next_job_skips_duplicate_content_hash(tmp_path: Path) -> None:

--- a/shared/README.md
+++ b/shared/README.md
@@ -12,6 +12,7 @@ the Python table definitions and repository helpers used by the services.
 ## Responsibilities
 
 - Environment configuration.
+- Shared path-validation and local file-cleanup helpers for deletion flows.
 - Logging setup.
 - Shared API response schemas.
 - SQLAlchemy metadata table definitions for PostgreSQL.

--- a/shared/file_cleanup.py
+++ b/shared/file_cleanup.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validate_path_under_roots(path: str | Path, roots: tuple[Path, ...]) -> Path:
+    """Return a resolved path after verifying it is under one configured root."""
+    if not roots:
+        raise ValueError("WATCH_ROOTS must contain at least one path for document deletion.")
+    for root in roots:
+        try:
+            return validate_path_under_root(path, root)
+        except ValueError:
+            continue
+    raise ValueError(f"Path is outside configured watch roots: {path}")
+
+
+def validate_path_under_root(path: str | Path, root: Path) -> Path:
+    """Return a resolved path after verifying it is under one configured root."""
+    resolved_path = resolve_path(Path(path))
+    resolved_root = resolve_path(root)
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as error:
+        raise ValueError(f"Path is outside configured root: {path}") from error
+    return resolved_path
+
+
+def is_path_under_roots(path: str | Path, roots: tuple[Path, ...]) -> bool:
+    """Return whether a path resolves under any configured root."""
+    return any(is_path_under_root(path, root) for root in roots)
+
+
+def is_path_under_root(path: str | Path, root: Path) -> bool:
+    """Return whether a path resolves under one configured root."""
+    try:
+        validate_path_under_root(path, root)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_path(path: Path) -> Path:
+    """Resolve a path for safety checks without requiring it to exist."""
+    return path.expanduser().resolve(strict=False)
+
+
+def validate_file_cleanup_targets(paths: list[Path]) -> None:
+    """Reject cleanup targets that exist but are not regular files."""
+    for path in paths:
+        if path.exists() and not path.is_file():
+            raise ValueError(f"Deletion target is not a file: {path}")
+
+
+def delete_file_if_present(path: Path) -> bool:
+    """Delete one file if present and return whether it was removed."""
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def delete_unique_files(paths: list[Path]) -> list[str]:
+    """Delete each unique file path at most once and return deleted paths."""
+    deleted: list[str] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        if delete_file_if_present(path):
+            deleted.append(str(path))
+    return deleted

--- a/shared/tests/unit/test_file_cleanup.py
+++ b/shared/tests/unit/test_file_cleanup.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from shared.file_cleanup import (
+    delete_file_if_present,
+    delete_unique_files,
+    is_path_under_roots,
+    validate_file_cleanup_targets,
+    validate_path_under_root,
+    validate_path_under_roots,
+)
+
+
+def test_validate_path_under_roots_accepts_configured_root(tmp_path: Path) -> None:
+    root = tmp_path / "watch"
+    source = root / "notes.md"
+
+    assert validate_path_under_roots(source, (root,)) == source.resolve(strict=False)
+
+
+def test_validate_path_under_roots_rejects_outside_path(tmp_path: Path) -> None:
+    root = tmp_path / "watch"
+    outside = tmp_path / "outside.md"
+
+    try:
+        validate_path_under_roots(outside, (root,))
+    except ValueError as error:
+        assert str(error) == f"Path is outside configured watch roots: {outside}"
+    else:
+        raise AssertionError("expected outside path to be rejected")
+
+
+def test_validate_path_under_root_rejects_outside_path(tmp_path: Path) -> None:
+    root = tmp_path / "watch"
+    outside = tmp_path / "outside.md"
+
+    try:
+        validate_path_under_root(outside, root)
+    except ValueError as error:
+        assert str(error) == f"Path is outside configured root: {outside}"
+    else:
+        raise AssertionError("expected outside path to be rejected")
+
+
+def test_is_path_under_roots_returns_false_for_outside_path(tmp_path: Path) -> None:
+    assert is_path_under_roots(tmp_path / "outside.md", (tmp_path / "watch",)) is False
+
+
+def test_validate_file_cleanup_targets_rejects_directory(tmp_path: Path) -> None:
+    directory = tmp_path / "directory"
+    directory.mkdir()
+
+    try:
+        validate_file_cleanup_targets([directory])
+    except ValueError as error:
+        assert str(error) == f"Deletion target is not a file: {directory}"
+    else:
+        raise AssertionError("expected directory cleanup target to be rejected")
+
+
+def test_delete_file_if_present_returns_whether_file_was_removed(tmp_path: Path) -> None:
+    target = tmp_path / "target.md"
+    target.write_text("content", encoding="utf-8")
+
+    assert delete_file_if_present(target) is True
+    assert delete_file_if_present(target) is False
+
+
+def test_delete_unique_files_deletes_each_path_once(tmp_path: Path) -> None:
+    target = tmp_path / "target.md"
+    target.write_text("content", encoding="utf-8")
+
+    assert delete_unique_files([target, target]) == [str(target)]
+    assert not target.exists()


### PR DESCRIPTION
### **User description**
## Summary

Implements watch-root deletion reconciliation for full-scan ingestion jobs.

- Reconciles active documents whose source files are missing under healthy watch roots
- Skips destructive reconciliation for unhealthy watch roots while still processing healthy roots
- Keeps requested single-path jobs non-destructive
- Documents cron/systemd-style scheduled operation using the existing one-shot worker

Closes #28

## Validation

- `python -m pytest ingestion_worker/tests/unit/test_pipeline.py -v`
- `make test.unit`
- `make typecheck`
- `make lint`
- `make test.smoke`


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Implements watch-root deletion reconciliation for full-scan ingestion jobs.

- Removes missing source files from metadata, vector index, and managed store.

- Skips destructive reconciliation for documents under unhealthy watch roots.

- Refactors file path validation and cleanup into a new shared utility module.

- Updates documentation for scheduled worker operation and reconciliation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Ingestion Worker] --> B{Job Type?};
  B -- "Requested Path" --> C[Process Single Path];
  B -- "Full Scan" --> D[Scan Watch Roots];
  D --> E{Healthy Roots?};
  E -- "Yes" --> F[Reconcile Missing Files];
  E -- "No" --> G[Skip Unhealthy Root Reconciliation];
  F --> H[Delete Document];
  H --> I[Metadata Repository];
  H --> J[Vector Index];
  H --> K[Managed Store];
  C --> L[Process Source Paths];
  F --> L;
  G --> L;
  L --> M[Update Ingestion Job];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main.py</strong><dd><code>Refactor file cleanup utilities to shared module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-992287f42f167ab442781b4871fdd4be342978c1bfe7820972abcca09773a764">+12/-51</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pipeline.py</strong><dd><code>Implement watch-root deletion reconciliation for full-scan jobs</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-396a7a697d50b42f2704f7a520b435b0d6e571bed921842650107a8d9d4ad59a">+119/-17</a></td>

</tr>

<tr>
  <td><strong>file_cleanup.py</strong><dd><code>Introduce shared file path validation and cleanup utilities</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-c98c9904f92d33677e125793ee9b6ba0ee5e18bd5d79243f27310d076bb4259b">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_pipeline.py</strong><dd><code>Add unit tests for watch-root deletion reconciliation logic</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-9483bc533626b5aade1281c24a8662bea27257c850ec7893dc453914670525d3">+197/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_file_cleanup.py</strong><dd><code>Add unit tests for shared file cleanup utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-815db901c2d8d6783e15e11c8d464691bb472a68403109629ecd6d7f5bb9922f">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update documentation for reconciliation and scheduled worker operation</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-a885046f76b95c2ffc2ff27bee22a4e0094da0c45ced0b97726425f13ccac8e2">+26/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update README to reflect new file cleanup utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/34/files#diff-8e14ddd6c044992ed17f785e7e9eb16ae030e240c11f026a76705af0dcc5831b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

