### PR TITLE
Publish service container images to GHCR and document image tags

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,73 @@
+name: Publish Service Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: api-service
+            dockerfile: api_service/Dockerfile
+          - service: ingestion-worker
+            dockerfile: ingestion_worker/Dockerfile
+          - service: embedding-service
+            dockerfile: embedding_service/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v0\.0\.[0-9]+$ ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            latest_patch=$(git tag -l 'v0.0.*' | sed -E 's/^v0\.0\.([0-9]+)$/\1/' | sort -n | tail -n1)
+            if [[ -z "${latest_patch}" ]]; then
+              latest_patch=0
+            fi
+            version="0.0.$((latest_patch + 1))"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/rag-${{ matrix.service }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=${{ steps.version.outputs.version }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -7,6 +7,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Manual release version tag (for example: 0.0.1)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -27,8 +32,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: docker/setup-buildx-action@v3
 
@@ -43,14 +46,12 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v0\.0\.[0-9]+$ ]]; then
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME#v}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            version="${{ github.event.inputs.release_version }}"
           else
-            latest_patch=$(git tag -l 'v0.0.*' | sed -E 's/^v0\.0\.([0-9]+)$/\1/' | sort -n | tail -n1)
-            if [[ -z "${latest_patch}" ]]; then
-              latest_patch=0
-            fi
-            version="0.0.$((latest_patch + 1))"
+            version=""
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
@@ -61,7 +62,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/rag-${{ matrix.service }}
           tags: |
             type=raw,value=sha-${{ github.sha }}
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Deployable services are published to GitHub Container Registry (GHCR):
 - `ghcr.io/<owner>/rag-ingestion-worker`
 - `ghcr.io/<owner>/rag-embedding-service`
 
-Image tags are immutable and intended for deployments:
+Image tags are intended for deployments, but tags can be moved if republished; pin by digest when you need an immutable reference:
 
-- `sha-<full_commit_sha>` for every published build.
+- `sha-<full_commit_sha>` for every published build, for traceability to a specific source commit.
 - Manually selected release version tags (for example: `0.0.1`) via Git tag (`v0.0.1`) or manual workflow dispatch input.
 
 Avoid using `latest` for cluster deployments.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,18 @@ Do not put personal secrets in the committed env defaults; override values in yo
 - Dedicated `embedding-service`, co-located with Ollama/Gemma on the Mac M2 model host by default.
 - Hybrid dense + sparse retrieval.
 - Immutable document versions and explicit ingestion state.
+
+## Container Images
+
+Deployable services are published to GitHub Container Registry (GHCR):
+
+- `ghcr.io/<owner>/rag-api-service`
+- `ghcr.io/<owner>/rag-ingestion-worker`
+- `ghcr.io/<owner>/rag-embedding-service`
+
+Image tags are immutable and intended for deployments:
+
+- `sha-<full_commit_sha>` for every published build.
+- `0.0.N` incremental version tags starting at `0.0.1`.
+
+Avoid using `latest` for cluster deployments.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Deployable services are published to GitHub Container Registry (GHCR):
 Image tags are immutable and intended for deployments:
 
 - `sha-<full_commit_sha>` for every published build.
-- `0.0.N` incremental version tags starting at `0.0.1`.
+- Manually selected release version tags (for example: `0.0.1`) via Git tag (`v0.0.1`) or manual workflow dispatch input.
 
 Avoid using `latest` for cluster deployments.


### PR DESCRIPTION
### **User description**
### Motivation

- Provide an automated way to build and publish service container images for deployments. 
- Ensure images are versioned and immutable for cluster deployments. 
- Document the published image names and tagging conventions in the repository README.

### Description

- Add a new GitHub Actions workflow `publish-images.yml` that builds and pushes images for `api-service`, `ingestion-worker`, and `embedding-service` to GitHub Container Registry using `docker/setup-buildx-action`, `docker/login-action`, and `docker/build-push-action`. 
- Implement release version resolution in the workflow with tag-aware logic and incremental `0.0.N` patch calculation for non-tagged pushes. 
- Use `docker/metadata-action` to attach `sha-<commit>` and resolved `0.0.N` tags and labels to published images. 
- Update `README.md` to document the GHCR image names and the tagging scheme (immutable `sha-<full_commit_sha>` and incremental `0.0.N`) and advise against using `latest` for deployments.

### Testing

- No automated test suite changes were added and no CI test jobs were executed as part of this change. 
- The workflow was added in YAML and should be exercised on `main` pushes or `v*` tags to validate the build-and-publish behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020db2742c832297f5440ad8b884e0)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add GitHub Actions workflow for publishing service images.

- Publish `api-service`, `ingestion-worker`, `embedding-service` to GHCR.

- Implement `sha-<commit>` and `0.0.N` version tagging logic.

- Document GHCR image names and tagging in `README.md`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Push to main / Tag v*] --> B{Publish Service Images Workflow};
  B --> C[Resolve Release Version];
  C --> D[Build & Push Images];
  D --> E[GitHub Container Registry (GHCR)];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish-images.yml</strong><dd><code>Add GitHub Actions workflow for publishing service images</code></dd></summary>
<hr>

.github/workflows/publish-images.yml

<ul><li>Introduces a new GitHub Actions workflow <code>publish-images.yml</code> for <br>building and pushing service images.<br> <li> Configures the workflow to trigger on <code>main</code> branch pushes, <code>v*</code> tags, or <br>manual <code>workflow_dispatch</code>.<br> <li> Implements logic to resolve image versions, using <code>v0.0.N</code> tags or <br>incrementing the patch version for non-tag pushes.<br> <li> Uses <code>docker/build-push-action</code> to build and push <code>api-service</code>, <br><code>ingestion-worker</code>, and <code>embedding-service</code> images to GHCR with <code>sha-<commit></code> and <br><code>0.0.N</code> tags.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/40/files#diff-bc3aae4bf6a5b8803897d5a659da30f07feccfadea77ad80d37c295576cf873f">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document GHCR image names and tagging conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds a new "Container Images" section to the <code>README.md</code>.<br> <li> Documents the GHCR image names for <code>rag-api-service</code>, <br><code>rag-ingestion-worker</code>, and <code>rag-embedding-service</code>.<br> <li> Explains the immutable tagging conventions, including <code>sha-<full_commit_sha></code> and <br>incremental <code>0.0.N</code> versions.<br> <li> Advises against using the <code>latest</code> tag for cluster deployments.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/40/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

