### PR TITLE
Docs/ADRs: switch to Kubernetes‑first deployment, update Helm chart reference and operational guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Architecture-first personal Retrieval-Augmented Generation system for a single-user, self-hosted knowledge base.
 
-The project is currently in the design/scaffolding phase. The documentation site captures the architecture decisions, service boundaries, and implementation plan.
+The project is implementation-ready, with containerized services, automated checks, and a reusable Helm chart for cluster deployments. The documentation site captures the architecture decisions, service boundaries, and operational contracts.
 
 ## Documentation
 
@@ -42,11 +42,11 @@ Configuration is environment-variable driven. Safe service-specific defaults are
 
 Do not put personal secrets in the committed env defaults; override values in your shell, Compose environment, ignored `.env.local`, or deployment-specific env files.
 
-## Current Architecture Direction
+## Current Deployment Direction
 
-- Dockerized services.
+- Kubernetes (Helm) is the primary deployment mode for homelab/runtime environments.
 - Watch directories are the authoritative corpus source.
-- PostgreSQL metadata store on NAS.
+- Docker Compose is local development/test scaffolding, not the primary runtime deployment path.
 - Qdrant vector store as an independent Docker service, defaulting to NAS placement.
 - `api-service` and `ingestion-worker` split from the start.
 - Dedicated `embedding-service`, co-located with Ollama/Gemma on the Mac M2 model host by default.
@@ -73,7 +73,7 @@ Avoid using `latest` for cluster deployments.
 The reusable Kubernetes chart is published as an OCI Helm chart:
 
 ```text
-oci://ghcr.io/<owner>/charts/rag
+oci://ghcr.io/kmikol/charts/rag
 ```
 
 Release deployments should pin a concrete chart version and matching service

--- a/docs/adr/002-storage-and-metadata-topology.md
+++ b/docs/adr/002-storage-and-metadata-topology.md
@@ -7,6 +7,7 @@
 | Status       | Accepted                                   |
 | Deciders     | System owner                               |
 | Date         | 2025-04-24                                 |
+| Last Reviewed| 2026-05-15                                 |
 | Supersedes   | —                                          |
 | Depends on   | ADR-000, ADR-001                           |
 
@@ -14,7 +15,7 @@
 
 ## Context
 
-The system is intended to run as a collection of small services packaged as Docker containers. Components may be moved between machines on the owner's Tailscale network. The data layer therefore needs to be central enough that services can be relocated without moving the corpus, while still remaining simple enough for a single-user self-hosted deployment.
+The system is intended to run as a collection of small services, with Kubernetes as the primary runtime deployment target and Docker Compose available for local development. Components may be moved between machines on the owner's Tailscale network. The data layer therefore needs to be central enough that services can be relocated without moving the corpus, while still remaining simple enough for a single-user self-hosted deployment.
 
 The system needs persistent storage for:
 
@@ -30,13 +31,13 @@ ADR-001 establishes that configured watch directories are the authoritative sour
 
 ## Decision
 
-The system will use **PostgreSQL as the central metadata store**, served from the Synology NAS as a Docker-managed service.
+The system will use **PostgreSQL as the central metadata store**, provided as a central service reachable from the cluster (commonly NAS-hosted in the homelab).
 
 PostgreSQL will store document metadata, source path records, SHA-256 content hashes, document lifecycle state, chunk metadata, ingestion job records, and any other relational state required by the ingestion and retrieval pipelines.
 
-The managed document store will live on NAS-backed storage and contain copied source files addressed by stable internal IDs.
+The managed document store will live on durable storage reachable from the cluster and contain copied source files addressed by stable internal IDs.
 
-The vector store will be packaged as an independent Docker service, currently expected to be **Qdrant**. The reference deployment will run Qdrant on the Synology NAS alongside PostgreSQL and the managed document store. Qdrant's location must be configured by service URL rather than assumed by the application, so it can be moved to a compute machine later if NAS RAM, disk latency, or query performance become limiting.
+The vector store will be packaged as an independent service, currently expected to be **Qdrant**. The reference deployment runs Qdrant with durable storage in the Kubernetes stack, while still allowing external placement if needed. Qdrant's location must be configured by service URL rather than assumed by the application, so it can be moved to a compute machine later if NAS RAM, disk latency, or query performance become limiting.
 
 Services must connect to PostgreSQL over the private Tailscale/network boundary using configured connection strings and credentials. Services must not share a SQLite database file over a network filesystem.
 
@@ -54,8 +55,8 @@ This also improves the portfolio value of the project: the architecture demonstr
 
 ## Implications
 
-- A PostgreSQL container/service must be part of the deployment stack.
-- A Qdrant container/service must be part of the deployment stack.
+- A PostgreSQL service reachable from the cluster must be part of the deployment stack (in-cluster or external).
+- A Qdrant service with durable storage must be part of the deployment stack (in-cluster or external).
 - Database schema migrations are required.
 - Service configuration must include PostgreSQL host, port, database, username, password, and TLS/connection settings as needed.
 - Service configuration must include the Qdrant endpoint. The application must not assume Qdrant is co-located with PostgreSQL or the API service.
@@ -91,8 +92,8 @@ Deferred. Running Qdrant close to the retrieval and embedding services may impro
 
 This ADR should be revisited if any of the following occur:
 
-- The NAS proves too slow or unreliable for PostgreSQL.
-- The NAS proves too slow or memory-constrained for Qdrant.
+- The selected PostgreSQL host proves too slow or unreliable.
+- The selected Qdrant placement proves too slow or memory-constrained.
 - The system is simplified back into a single-process deployment.
 - Multiple users or public access are introduced.
 - Backup and recovery requirements become stricter.

--- a/docs/adr/003-service-boundaries.md
+++ b/docs/adr/003-service-boundaries.md
@@ -7,6 +7,7 @@
 | Status       | Accepted                                   |
 | Deciders     | System owner                               |
 | Date         | 2025-04-24                                 |
+| Last Reviewed| 2026-05-15                                 |
 | Supersedes   | —                                          |
 | Depends on   | ADR-000, ADR-001, ADR-002                  |
 
@@ -14,7 +15,7 @@
 
 ## Context
 
-The system should be deployable as a collection of Docker services that can be moved between machines on the owner's Tailscale network. At the same time, this is a single-user personal system, so the first implementation should avoid unnecessary distributed-system complexity.
+The system should be deployable as Kubernetes workloads (primary) and as Docker services for local development, while remaining movable between machines on the owner's Tailscale network. At the same time, this is a single-user personal system, so the first implementation should avoid unnecessary distributed-system complexity.
 
 The main application responsibilities are:
 
@@ -49,10 +50,10 @@ The first implementation will use a **hybrid service split**:
   - Writes managed document copies, PostgreSQL metadata, and Qdrant vectors.
 
 - `postgres`
-  - Central metadata store, served from the NAS as decided in ADR-002.
+  - Central metadata store, reachable from the cluster as decided in ADR-002.
 
 - `qdrant`
-  - Independent vector store Docker service, defaulting to NAS deployment as decided in ADR-002.
+  - Independent vector store service with durable storage as decided in ADR-002.
 
 - `ollama`
   - Generation model server, running on the GPU-capable machine or another configured host.
@@ -73,7 +74,7 @@ The codebase should still preserve clear module boundaries so a future architect
 
 ## Implications
 
-- API and ingestion worker must be separate Docker images or separately runnable service commands.
+- API and ingestion worker must be separate deployable workloads (separate images/commands).
 - Both services need access to PostgreSQL and Qdrant configuration.
 - The ingestion worker needs access to configured watch roots and the managed document store.
 - The API service should not perform heavy ingestion work directly; `POST /ingest` should create or request a job for the worker to execute.

--- a/docs/adr/004-embedding-service.md
+++ b/docs/adr/004-embedding-service.md
@@ -7,6 +7,7 @@
 | Status       | Accepted                                   |
 | Deciders     | System owner                               |
 | Date         | 2025-04-24                                 |
+| Last Reviewed| 2026-05-15                                 |
 | Supersedes   | —                                          |
 | Depends on   | ADR-000, ADR-002, ADR-003                  |
 
@@ -19,13 +20,13 @@ Both ingestion and retrieval require embeddings:
 - During ingestion, document chunks are embedded before being written to the vector store.
 - During query handling, user queries are embedded before retrieval.
 
-The system is expected to run as Docker services that can move between machines on the private Tailscale network. Embedding model choice, version, and deployment location should therefore be centralized rather than duplicated across multiple services.
+The system is expected to run primarily on Kubernetes, with Docker-based local development, and services can move between machines on the private Tailscale network. Embedding model choice, version, and deployment location should therefore be centralized rather than duplicated across multiple services.
 
 ---
 
 ## Decision
 
-The system will include a dedicated **`embedding-service`** Docker service.
+The system will include a dedicated **`embedding-service`** service workload.
 
 Both `api-service` and `ingestion-worker` will call `embedding-service` over an internal HTTP API:
 
@@ -44,7 +45,7 @@ The reference deployment will run `embedding-service` on the same Mac M2 16GB ma
 
 A dedicated embedding service keeps the embedding model and version canonical. It avoids loading the same model independently in both the API and ingestion worker, reduces the risk of model drift, and allows the embedding workload to move to whichever machine has the best CPU/GPU/RAM characteristics.
 
-This service boundary fits the project's Docker-first architecture. It also makes future changes easier: the model can be replaced, optimized, or accelerated inside one service without changing API or ingestion business logic.
+This service boundary fits the project's service-oriented architecture and Kubernetes-first runtime direction. It also makes future changes easier: the model can be replaced, optimized, or accelerated inside one service without changing API or ingestion business logic.
 
 The trade-off is one extra network call in the query path. For a single-user system on a private network, this cost is acceptable, and it is likely to be small compared with local LLM generation latency.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -19,7 +19,7 @@ Each ADR follows a standard format:
 |----|-------|--------|---------|
 | [000](000-problem-definition-and-scope.md) | Problem Definition and Scope | Accepted | Defines the single-user, self-hosted, local-model RAG system scope and constraints |
 | [001](001-data-sources-and-ingestion.md) | Data Sources and Ingestion | Accepted | Watch directories are authoritative; PDF and Markdown are initial formats |
-| [002](002-storage-and-metadata-topology.md) | Storage and Metadata Topology | Accepted | PostgreSQL runs centrally on NAS; Qdrant is an independent movable Docker service |
+| [002](002-storage-and-metadata-topology.md) | Storage and Metadata Topology | Accepted | PostgreSQL is central and cluster-reachable; Qdrant is an independent movable service with durable storage |
 | [003](003-service-boundaries.md) | Service Boundaries | Accepted | Initial split uses `api-service` and `ingestion-worker`, with retrieval/generation internal to API |
 | [004](004-embedding-service.md) | Embedding Service | Accepted | Dedicated `embedding-service` handles query and batch embeddings |
 | [005](005-document-identity-and-ingestion-state.md) | Document Identity and Ingestion State | Accepted | Logical documents have immutable indexed versions and explicit ingestion states |
@@ -50,3 +50,8 @@ Each ADR follows a standard format:
 2. **Local but movable**: Services should run privately and move between machines by configuration.
 3. **Simple first, extensible later**: Use clear interfaces and defer heavier infrastructure until it is justified.
 4. **Observable decisions**: Architecture choices should be documented and traceable.
+
+
+## ADR Review Log
+
+- **2026-05-15**: Reviewed ADR-002, ADR-003, and ADR-004 to align deployment language with Kubernetes-first runtime direction while preserving private Tailscale/LAN assumptions.

--- a/docs/getting-started/deployment-guide.md
+++ b/docs/getting-started/deployment-guide.md
@@ -1,7 +1,7 @@
 # Getting Started: Deploy and Use the RAG
 
-This guide describes how to deploy the personal RAG system on a NAS, server, or
-private LAN/Tailscale host, then ingest documents and query them through the API.
+This guide describes how to deploy the personal RAG system on a personal Kubernetes
+cluster (private LAN/Tailscale), then ingest documents and query them through the API.
 
 The system is single-user and private. Keep it on a trusted private network
 unless a future deployment adds a reverse proxy, TLS, and stronger exposure
@@ -152,12 +152,11 @@ Use `:` between multiple watch roots on Linux-based servers. Every path listed
 in `WATCH_ROOTS` must be mounted into both `api-service` and
 `ingestion-worker`.
 
-## Compose Example for a NAS or Server
+## Local Docker Compose (Development Only)
 
-The checked-in `docker-compose.yml` is a local development baseline. For a
-server deployment, add persistent volumes and real env files. This example keeps
-all application services on the NAS/server and points them at an Ollama host on
-the private network:
+The checked-in `docker-compose.yml` is a local development baseline only.
+Primary runtime deployments should use the Helm chart and cluster-owned values/secrets.
+Use this Compose example only for local iteration or troubleshooting outside the cluster:
 
 ```yaml
 services:
@@ -239,7 +238,7 @@ a reviewed public-access setup.
 
 ## First Start
 
-Build the images and start the long-running services:
+For local development, build the images and start services:
 
 ```bash
 docker compose up -d --build postgres qdrant embedding-service api-service ingestion-worker

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -40,11 +40,11 @@ Serve the documentation locally:
 make docs.serve.local
 ```
 
-## Planned Runtime Prerequisites
+## Runtime Deployment Prerequisites (Kubernetes-first)
 
-- Docker or Docker-compatible runtime.
+- Kubernetes cluster with Helm (primary runtime target).
 - Access to the private Tailscale/LAN network.
-- NAS-hosted PostgreSQL.
-- Qdrant Docker service, defaulting to NAS placement.
+- PostgreSQL reachable from the cluster (often external to the chart).
+- Qdrant deployed by the chart with durable storage, or an equivalent managed deployment.
 - Ollama on the model host.
 - Configured watch roots containing supported documents.


### PR DESCRIPTION
### **User description**
### Motivation

- Update the project's operational stance from a NAS/Docker-first reference to a Kubernetes/Helm-first runtime while preserving single-user, private-network assumptions.
- Clarify service placement expectations for PostgreSQL, Qdrant, and embedding/generation hosts so deployments are cluster-aware and portable.
- Make documentation and ADRs reflect the current implementation readiness and the published Helm chart location.

### Description

- Revise `README.md` to mark the project as implementation-ready, emphasize containerized services, add automated checks, and point at the reusable Helm chart; update the OCI chart reference to `oci://ghcr.io/kmikol/charts/rag`.
- Update ADRs (002, 003, 004 and ADR index) to prefer Kubernetes as the primary runtime target, change wording from NAS-hosted to cluster-reachable services, add `Last Reviewed` dates, and add an ADR review log entry for 2026-05-15.
- Adjust the deployment guide and setup docs to label Docker Compose as a local development scaffold, recommend using the Helm chart for primary deployments, and clarify expectations for PostgreSQL and Qdrant placement and durability.

### Testing

- This is a documentation-only change with no code or schema modifications, so no unit/integration tests were required for the diff itself.
- Built and served the docs locally with `make docs.serve.local` to verify site rendering and referenced strings, and the local build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a53407608322a5143e9178a4af45)


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Shift deployment strategy from Docker-first to Kubernetes/Helm.

- Update Architectural Decision Records (ADRs) for Kubernetes-first runtime.

- Clarify PostgreSQL and Qdrant service placement as cluster-reachable.

- Relegate Docker Compose to local development scaffolding.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker-first Deployment (Previous)"] --> B{"Update Deployment Strategy"};
  B --> C["Kubernetes/Helm-first Deployment (New)"];
  C --> D["Updated ADRs & Deployment Guides"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update project status, deployment direction, and Helm chart reference</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.md</strong><dd><code>Update ADR-002 summary and add ADR review log entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-a2209ef13bde8abaeb681dc5ffce277d8a410a4bec1a19182a374a09c017bc17">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deployment-guide.md</strong><dd><code>Update deployment target to Kubernetes and relegate Docker Compose</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-98adcadf492dfa6420ec501649efda09ff7c87746cc121ac5f3d822586ca4537">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup.md</strong><dd><code>Update runtime prerequisites to reflect Kubernetes-first deployment</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-527a8429a3b62b0c31ddad5438ca3255b640005ee4ed9566ac8727fe58205a2b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Architectural changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>002-storage-and-metadata-topology.md</strong><dd><code>Update storage context for Kubernetes and clarify service placement</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-c784453cc87988ddb6ea4ecf50d19f539f278752b38811a8497da28803f0c869">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>003-service-boundaries.md</strong><dd><code>Update service boundary context for Kubernetes and clarify service </code><br><code>placement</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-cd311492a7f9b00cf6399512ebe3805af79369a266d62c176fc895351d274f6b">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>004-embedding-service.md</strong><dd><code>Update embedding service context for Kubernetes and service type</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/47/files#diff-a0ae6cc00127c6b9595dd40c94b2e00b112ed42c1e821b88f6221c6a476568ac">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

