### PR TITLE
[codex] Stabilize provider-backed E2E CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test.e2e: ## Run provider-backed end-to-end RAG tests in Docker
 	if [ $$EXIT -ne 0 ]; then \
 		echo "E2E test failed; collecting Docker Compose diagnostics before teardown"; \
 		$(E2E_COMPOSE) ps; \
-		$(E2E_COMPOSE) logs --no-color api-service embedding-service ingestion-worker test; \
+		$(E2E_COMPOSE) logs --no-color; \
 	fi; \
 	$(E2E_COMPOSE) down -v; \
 	exit $$EXIT

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ test.e2e: ## Run provider-backed end-to-end RAG tests in Docker
 	@test -n "$$GEMINI_API_KEY_E2E_TEST" || (echo "GEMINI_API_KEY_E2E_TEST is required for test.e2e"; exit 2)
 	$(E2E_COMPOSE) run --build --rm test; \
 	EXIT=$$?; \
+	if [ $$EXIT -ne 0 ]; then \
+		echo "E2E test failed; collecting Docker Compose diagnostics before teardown"; \
+		$(E2E_COMPOSE) ps; \
+		$(E2E_COMPOSE) logs --no-color api-service embedding-service ingestion-worker test; \
+	fi; \
 	$(E2E_COMPOSE) down -v; \
 	exit $$EXIT
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -56,7 +56,7 @@ services:
       EMBEDDING_MODEL_NAME: gemini-embedding-2
       LLM_PROVIDER: google_genai
       LLM_ENDPOINT_URL: https://generativelanguage.googleapis.com/v1beta
-      LLM_MODEL: gemma-4-31b-it
+      LLM_MODEL: gemini-3.1-flash-lite
       LLM_API_KEY: ${GEMINI_API_KEY_E2E_TEST:?Set GEMINI_API_KEY_E2E_TEST}
       LLM_TIMEOUT_SECONDS: 180
       CHAT_MIN_TOP_SCORE: 0.5

--- a/docs/getting-started/running.md
+++ b/docs/getting-started/running.md
@@ -47,7 +47,7 @@ GEMINI_API_KEY_E2E_TEST=...
 
 The E2E Compose stack sets `EMBEDDING_MODEL_NAME=gemini-embedding-2` for
 Google embeddings and fixes the chat model to Google's API model id
-`gemma-4-31b-it`.
+`gemini-3.1-flash-lite`.
 
 Run:
 


### PR DESCRIPTION
### **User description**
## Summary

- Switch the provider-backed E2E chat model from `gemma-4-31b-it` to `gemini-3.1-flash-lite`.
- Update the E2E docs to match the Google chat model used by Compose.
- Print Docker Compose service status and logs for all E2E services before teardown when `make test.e2e` fails.

## Why

The E2E stack was reaching the final `/chat` boundary successfully, but Google returned intermittent `500 InternalServerError` responses for `gemma-4-31b-it`. Direct provider smoke tests and a local full E2E run showed `gemini-3.1-flash-lite` completes the same path successfully.

The broader diagnostics also make future provider or service failures visible in CI logs before Compose volumes and containers are removed.

## Validation

- Provider-backed Docker E2E with `gemini-3.1-flash-lite`: `1 passed, 1 warning`
- `docker compose -f docker-compose.e2e.yml run --rm --no-deps test ruff check .`
- `docker compose -f docker-compose.e2e.yml run --rm --no-deps test ruff format --check .`
- `GEMINI_API_KEY_E2E_TEST=dummy make -n test.e2e`

## Notes

Host `make lint` could not run in this workspace because `ruff` is not installed on the host PATH, so the equivalent ruff checks were run inside the repo's Docker test image.


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Switch E2E chat model to `gemini-3.1-flash-lite`.

- Add Docker Compose diagnostics on E2E failure.

- Update E2E documentation for new model.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["make test.e2e"] --> B["Run E2E Tests (docker compose run test)"]
  B -- "Test Fails (exit code != 0)" --> C["Collect Docker Compose Diagnostics"]
  C --> D["Teardown Services (docker compose down -v)"]
  B -- "Test Succeeds" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add E2E test failure diagnostics to Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Added a conditional block to check the exit code of the E2E test run.<br> <li> If the test fails, it prints a diagnostic message.<br> <li> It then runs <code>docker compose ps</code> and <code>docker compose logs --no-color</code> to <br>collect service status and logs before teardown.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/48/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.e2e.yml</strong><dd><code>Switch E2E chat model to Gemini Flash Lite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.e2e.yml

<ul><li>Changed the <code>LLM_MODEL</code> for the <code>rag-api</code> service.<br> <li> Updated the model from <code>gemma-4-31b-it</code> to <code>gemini-3.1-flash-lite</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/48/files#diff-29d8d8c569345f7e4339e3bab5342fa39d73d2293303d372c0f00cd04ad242eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>running.md</strong><dd><code>Update E2E documentation for Gemini Flash Lite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/getting-started/running.md

<ul><li>Updated the documentation to reflect the new E2E chat model.<br> <li> Changed the mentioned model ID from <code>gemma-4-31b-it</code> to <br><code>gemini-3.1-flash-lite</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/kmikol/rag/pull/48/files#diff-78de9b65be9e2dcf0440494b86430f11208c37f9c997ef3e6761731560930313">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

