### PR TITLE
[codex] Add chart-owned Postgres option for RAG release

### DIFF
--- a/charts/rag/README.md
+++ b/charts/rag/README.md
@@ -12,7 +12,7 @@ Set these values for a production-like deployment:
 
 | Value | Purpose |
 | --- | --- |
-| `existingSecret` | Kubernetes Secret containing PostgreSQL credentials. |
+| `database.existingSecret` | Kubernetes Secret containing PostgreSQL credentials. |
 | `database.host` | PostgreSQL host reachable from the cluster when `postgresql.enabled=false`. |
 | `database.port` | PostgreSQL port. |
 | `database.name` | PostgreSQL database name. |
@@ -29,7 +29,7 @@ Set these values for a production-like deployment:
 | `qdrant.persistence` | Durable vector-store storage configuration. |
 
 The chart builds `POSTGRES_URL` for `api-service` and `ingestion-worker` from
-`existingSecret` and `database.*`. When `postgresql.enabled=true`, the database
+`database.existingSecret` and `database.*`. When `postgresql.enabled=true`, the database
 host resolves to the chart-owned PostgreSQL Service. Otherwise, `database.host`
 must point at an external PostgreSQL service reachable from the cluster. The
 chart also sets in-cluster `QDRANT_URL` and `EMBEDDING_SERVICE_URL` values for

--- a/charts/rag/README.md
+++ b/charts/rag/README.md
@@ -13,9 +13,10 @@ Set these values for a production-like deployment:
 | Value | Purpose |
 | --- | --- |
 | `existingSecret` | Kubernetes Secret containing PostgreSQL credentials. |
-| `database.host` | PostgreSQL host reachable from the cluster. |
+| `database.host` | PostgreSQL host reachable from the cluster when `postgresql.enabled=false`. |
 | `database.port` | PostgreSQL port. |
 | `database.name` | PostgreSQL database name. |
+| `postgresql` | Optional chart-owned PostgreSQL workload and storage. |
 | `apiService.apiKey.existingSecret` | Kubernetes Secret containing the API bearer token. |
 | `apiService.env.WATCH_ROOTS` | Source corpus path list as seen by the API container. |
 | `apiService.env.DOCUMENT_STORE_PATH` | Managed document-copy path as seen by the API container. |
@@ -28,8 +29,11 @@ Set these values for a production-like deployment:
 | `qdrant.persistence` | Durable vector-store storage configuration. |
 
 The chart builds `POSTGRES_URL` for `api-service` and `ingestion-worker` from
-`existingSecret` and `database.*`. It sets in-cluster `QDRANT_URL` and
-`EMBEDDING_SERVICE_URL` values for the API and worker.
+`existingSecret` and `database.*`. When `postgresql.enabled=true`, the database
+host resolves to the chart-owned PostgreSQL Service. Otherwise, `database.host`
+must point at an external PostgreSQL service reachable from the cluster. The
+chart also sets in-cluster `QDRANT_URL` and `EMBEDDING_SERVICE_URL` values for
+the API and worker.
 
 ## Secrets
 
@@ -48,10 +52,12 @@ without inspecting application internals.
 
 ## Storage Contract
 
-Qdrant storage is backup-sensitive state and should use durable storage. The
-managed document store is also backup-sensitive unless source watch roots are
-the only recovery source you intend to keep. PostgreSQL is external to this
-chart and must be backed up outside the chart.
+Qdrant and PostgreSQL storage are backup-sensitive state and should use durable
+storage. The managed document store is also backup-sensitive unless source
+watch roots are the only recovery source you intend to keep. If PostgreSQL is
+external to this chart, it must be backed up outside the chart. If
+`postgresql.enabled=true`, the chart creates the database workload, service, and
+optional PVC, but database backup still remains an operator responsibility.
 
 The chart supports both chart-created PVCs and existing claims:
 
@@ -84,10 +90,12 @@ components so document deletion and ingestion operate on the same files.
 
 ## External Dependencies
 
-This chart does not deploy PostgreSQL, Ollama, or external LLM providers.
+This chart can deploy PostgreSQL, but it does not deploy Ollama or external LLM
+providers.
 Deployment repositories must provide:
 
-- PostgreSQL reachable from the cluster.
+- PostgreSQL reachable from the cluster, or set `postgresql.enabled=true` for a
+  chart-owned PostgreSQL instance.
 - Any required database schema migration process before serving real traffic.
 - Embedding endpoint placement, for example an in-cluster Ollama service or a
   private LAN/Tailnet endpoint.

--- a/charts/rag/examples/values.cluster-home-arpa.example.yaml
+++ b/charts/rag/examples/values.cluster-home-arpa.example.yaml
@@ -10,9 +10,22 @@ sharedStorage:
   mountPath: /data
 
 database:
-  host: postgresql.database.svc.cluster.local
   port: 5432
   name: rag
+
+postgresql:
+  enabled: true
+  persistence:
+    enabled: true
+    storageClassName: longhorn-r2
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
 
 apiService:
   apiKey:
@@ -22,10 +35,10 @@ apiService:
     QDRANT_COLLECTION: rag_chunks
     WATCH_ROOTS: /data/watch
     DOCUMENT_STORE_PATH: /data/documents
-    LLM_PROVIDER: openai_compatible
-    LLM_CHAT_COMPLETIONS_URL: http://ollama.default.svc.cluster.local:11434/v1/chat/completions
-    LLM_MODEL: gemma3:4b
-    LLM_TIMEOUT_SECONDS: "120"
+    LLM_PROVIDER: google_genai
+    LLM_ENDPOINT_URL: https://generativelanguage.googleapis.com/v1beta
+    LLM_MODEL: gemini-3.1-flash-lite
+    LLM_TIMEOUT_SECONDS: "180"
     CHAT_MIN_TOP_SCORE: "0.5"
     CHAT_MIN_USABLE_CHUNKS: "1"
     CHAT_MAX_CONTEXT_CHUNKS: "5"
@@ -74,11 +87,11 @@ ingestionWorker:
 
 embeddingService:
   env:
-    EMBEDDING_BACKEND: ollama
-    EMBEDDING_MODEL_NAME: embeddinggemma
+    EMBEDDING_BACKEND: google
+    EMBEDDING_MODEL_NAME: gemini-embedding-2
     EMBEDDING_DIMENSION: "768"
-    EMBEDDING_ENDPOINT_URL: http://ollama.default.svc.cluster.local:11434
-    EMBEDDING_TIMEOUT_SECONDS: "30"
+    EMBEDDING_ENDPOINT_URL: https://generativelanguage.googleapis.com/v1beta
+    EMBEDDING_TIMEOUT_SECONDS: "60"
     EMBEDDING_KEEP_ALIVE: 5m
   extraEnv:
     - name: EMBEDDING_API_KEY

--- a/charts/rag/examples/values.cluster-home-arpa.example.yaml
+++ b/charts/rag/examples/values.cluster-home-arpa.example.yaml
@@ -1,5 +1,3 @@
-existingSecret: rag-db-credentials
-
 sharedStorage:
   enabled: true
   create: true
@@ -10,6 +8,7 @@ sharedStorage:
   mountPath: /data
 
 database:
+  existingSecret: rag-db-credentials
   port: 5432
   name: rag
 

--- a/charts/rag/examples/values.example.yaml
+++ b/charts/rag/examples/values.example.yaml
@@ -1,6 +1,5 @@
-existingSecret: rag-db-credentials
-
 database:
+  existingSecret: rag-db-credentials
   host: postgresql.database.svc.cluster.local
   port: 5432
   name: rag

--- a/charts/rag/examples/values.example.yaml
+++ b/charts/rag/examples/values.example.yaml
@@ -5,6 +5,9 @@ database:
   port: 5432
   name: rag
 
+postgresql:
+  enabled: false
+
 apiService:
   apiKey:
     existingSecret: rag-api-credentials

--- a/charts/rag/examples/values.existing-storage.example.yaml
+++ b/charts/rag/examples/values.existing-storage.example.yaml
@@ -1,6 +1,5 @@
-existingSecret: rag-db-credentials
-
 database:
+  existingSecret: rag-db-credentials
   host: postgresql.database.svc.cluster.local
   port: 5432
   name: rag

--- a/charts/rag/examples/values.existing-storage.example.yaml
+++ b/charts/rag/examples/values.existing-storage.example.yaml
@@ -5,6 +5,9 @@ database:
   port: 5432
   name: rag
 
+postgresql:
+  enabled: false
+
 sharedStorage:
   enabled: true
   create: false

--- a/charts/rag/templates/_helpers.tpl
+++ b/charts/rag/templates/_helpers.tpl
@@ -34,6 +34,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "rag.databaseHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" (include "rag.fullname" .) -}}
+{{- else -}}
+{{- required "database.host is required when postgresql.enabled is false" .Values.database.host -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "rag.validate" -}}
 {{- if and .Values.sharedStorage.enabled (not .Values.sharedStorage.create) (not .Values.sharedStorage.existingClaim) -}}
 {{- fail "If sharedStorage.enabled is true, either sharedStorage.create must be true or sharedStorage.existingClaim must be provided." -}}

--- a/charts/rag/templates/_helpers.tpl
+++ b/charts/rag/templates/_helpers.tpl
@@ -42,6 +42,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "rag.databaseSecretName" -}}
+{{- required "database.existingSecret is required" .Values.database.existingSecret -}}
+{{- end -}}
+
 {{- define "rag.validate" -}}
 {{- if and .Values.sharedStorage.enabled (not .Values.sharedStorage.create) (not .Values.sharedStorage.existingClaim) -}}
 {{- fail "If sharedStorage.enabled is true, either sharedStorage.create must be true or sharedStorage.existingClaim must be provided." -}}

--- a/charts/rag/templates/api.yaml
+++ b/charts/rag/templates/api.yaml
@@ -32,12 +32,12 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.userSecretKey }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.passwordSecretKey }}
             - name: POSTGRES_URL
               value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"

--- a/charts/rag/templates/api.yaml
+++ b/charts/rag/templates/api.yaml
@@ -40,7 +40,7 @@ spec:
                   name: {{ required "existingSecret is required" .Values.existingSecret }}
                   key: {{ .Values.database.passwordSecretKey }}
             - name: POSTGRES_URL
-              value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ required "database.host is required" .Values.database.host }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
+              value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
             - name: QDRANT_URL
               value: "http://{{ include "rag.fullname" . }}-qdrant:{{ .Values.qdrant.service.port }}"
             - name: EMBEDDING_SERVICE_URL

--- a/charts/rag/templates/ingestion-cronjob.yaml
+++ b/charts/rag/templates/ingestion-cronjob.yaml
@@ -37,12 +37,12 @@ spec:
                 - name: POSTGRES_USER
                   valueFrom:
                     secretKeyRef:
-                      name: {{ required "existingSecret is required" .Values.existingSecret }}
+                      name: {{ include "rag.databaseSecretName" . }}
                       key: {{ .Values.database.userSecretKey }}
                 - name: POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ required "existingSecret is required" .Values.existingSecret }}
+                      name: {{ include "rag.databaseSecretName" . }}
                       key: {{ .Values.database.passwordSecretKey }}
                 - name: POSTGRES_URL
                   value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"

--- a/charts/rag/templates/ingestion-cronjob.yaml
+++ b/charts/rag/templates/ingestion-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                       name: {{ required "existingSecret is required" .Values.existingSecret }}
                       key: {{ .Values.database.passwordSecretKey }}
                 - name: POSTGRES_URL
-                  value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ required "database.host is required" .Values.database.host }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
+                  value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
                 - name: QDRANT_URL
                   value: "http://{{ include "rag.fullname" . }}-qdrant:{{ .Values.qdrant.service.port }}"
                 - name: EMBEDDING_SERVICE_URL

--- a/charts/rag/templates/ingestion-worker.yaml
+++ b/charts/rag/templates/ingestion-worker.yaml
@@ -40,12 +40,12 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.userSecretKey }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.passwordSecretKey }}
             - name: POSTGRES_URL
               value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"

--- a/charts/rag/templates/ingestion-worker.yaml
+++ b/charts/rag/templates/ingestion-worker.yaml
@@ -48,7 +48,7 @@ spec:
                   name: {{ required "existingSecret is required" .Values.existingSecret }}
                   key: {{ .Values.database.passwordSecretKey }}
             - name: POSTGRES_URL
-              value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ required "database.host is required" .Values.database.host }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
+              value: "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "rag.databaseHost" . }}:{{ .Values.database.port }}/{{ required "database.name is required" .Values.database.name }}"
             - name: QDRANT_URL
               value: "http://{{ include "rag.fullname" . }}-qdrant:{{ .Values.qdrant.service.port }}"
             - name: EMBEDDING_SERVICE_URL

--- a/charts/rag/templates/postgresql.yaml
+++ b/charts/rag/templates/postgresql.yaml
@@ -36,12 +36,12 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.userSecretKey }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  name: {{ include "rag.databaseSecretName" . }}
                   key: {{ .Values.database.passwordSecretKey }}
             {{- range $key, $value := .Values.postgresql.env }}
             - name: {{ $key }}

--- a/charts/rag/templates/postgresql.yaml
+++ b/charts/rag/templates/postgresql.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "rag.fullname" . }}-postgresql
+  labels:
+    {{- include "rag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  replicas: 1
+  serviceName: {{ include "rag.fullname" . }}-postgresql
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      serviceAccountName: {{ include "rag.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.postgresql.containerPort }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  key: {{ .Values.database.userSecretKey }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "existingSecret is required" .Values.existingSecret }}
+                  key: {{ .Values.database.passwordSecretKey }}
+            {{- range $key, $value := .Values.postgresql.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - {{ .Values.database.name }}
+            initialDelaySeconds: {{ .Values.postgresql.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.readinessProbe.periodSeconds }}
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - {{ .Values.database.name }}
+            initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.livenessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: {{ .Values.postgresql.persistence.mountPath }}
+          {{- end }}
+      {{- if .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-postgresql-data" (include "rag.fullname" .)) .Values.postgresql.persistence.existingClaim }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rag.fullname" . }}-postgresql
+  labels:
+    {{- include "rag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: {{ .Values.postgresql.service.type }}
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgresql
+  ports:
+    - port: {{ .Values.database.port }}
+      targetPort: {{ .Values.postgresql.containerPort }}
+      protocol: TCP
+      name: postgresql
+{{- end }}

--- a/charts/rag/templates/pvc.yaml
+++ b/charts/rag/templates/pvc.yaml
@@ -61,4 +61,20 @@ spec:
   {{- with .Values.qdrant.persistence.storageClassName }}
   storageClassName: {{ . }}
   {{- end }}
+---
+{{- end }}
+{{- if and .Values.postgresql.enabled .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rag.fullname" . }}-postgresql-data
+spec:
+  accessModes:
+    {{- toYaml .Values.postgresql.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size }}
+  {{- with .Values.postgresql.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/rag/values.yaml
+++ b/charts/rag/values.yaml
@@ -153,3 +153,30 @@ database:
   name: rag
   userSecretKey: DB_USER
   passwordSecretKey: DB_PASSWORD
+
+postgresql:
+  enabled: false
+  image:
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+  containerPort: 5432
+  env:
+    PGDATA: /var/lib/postgresql/data/pgdata
+  resources: {}
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 20
+  persistence:
+    enabled: false
+    existingClaim: ""
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ""
+    mountPath: /var/lib/postgresql/data

--- a/charts/rag/values.yaml
+++ b/charts/rag/values.yaml
@@ -11,8 +11,6 @@ rbac:
   create: false
   rules: []
 
-existingSecret: rag-db-credentials
-
 sharedStorage:
   enabled: false
   create: false
@@ -148,6 +146,7 @@ qdrant:
     mountPath: /qdrant/storage
 
 database:
+  existingSecret: rag-db-credentials
   host: postgresql
   port: 5432
   name: rag

--- a/docs/getting-started/homelab-helm-contract.md
+++ b/docs/getting-started/homelab-helm-contract.md
@@ -20,7 +20,7 @@ cluster manifests.
 
 The cluster values must provide:
 
-- `existingSecret` pointing at `rag-db-credentials`.
+- `database.existingSecret` pointing at `rag-db-credentials`.
 - `database.port` and `database.name`.
 - `database.host` when `postgresql.enabled=false`; otherwise the chart uses the
   chart-owned PostgreSQL Service.

--- a/docs/getting-started/homelab-helm-contract.md
+++ b/docs/getting-started/homelab-helm-contract.md
@@ -21,7 +21,10 @@ cluster manifests.
 The cluster values must provide:
 
 - `existingSecret` pointing at `rag-db-credentials`.
-- `database.host`, `database.port`, and `database.name`.
+- `database.port` and `database.name`.
+- `database.host` when `postgresql.enabled=false`; otherwise the chart uses the
+  chart-owned PostgreSQL Service.
+- `postgresql` configuration when the deployment should own its own database.
 - `apiService.apiKey.existingSecret` pointing at `rag-api-credentials`.
 - `apiService.env.WATCH_ROOTS` and `apiService.env.DOCUMENT_STORE_PATH`.
 - `ingestionWorker.env.WATCH_ROOTS` and `ingestionWorker.env.DOCUMENT_STORE_PATH`.
@@ -33,9 +36,10 @@ The cluster values must provide:
 
 ## Storage
 
-PostgreSQL is external and must be backed up outside this chart. Qdrant is
-backup-sensitive state. The managed document store is backup-sensitive unless
-the source corpus is the only recovery source you intend to keep.
+PostgreSQL and Qdrant are backup-sensitive state. The managed document store is
+backup-sensitive unless the source corpus is the only recovery source you
+intend to keep. If `postgresql.enabled=true`, this chart creates PostgreSQL and
+its optional PVC, but backup remains an operator responsibility.
 
 The chart supports both storage ownership models:
 
@@ -63,9 +67,9 @@ ingestionWorker:
 
 ## External Dependencies
 
-The chart does not deploy PostgreSQL, Ollama, or LLM providers. The cluster
-configuration must define where those services live and whether they are
-reachable through Kubernetes DNS, LAN DNS, or Tailscale.
+The chart can deploy PostgreSQL, but it does not deploy Ollama or LLM
+providers. The cluster configuration must define whether PostgreSQL is
+chart-owned or external, and where model/provider services live.
 
 Changing the embedding backend, model name, or vector dimension requires a new
 Qdrant collection or full reingestion.

--- a/tests/smoke/test_helm_chart.py
+++ b/tests/smoke/test_helm_chart.py
@@ -48,20 +48,28 @@ def test_cluster_home_arpa_values_render_homelab_contract() -> None:
     postgresql_container = _container(postgresql, "postgresql")
     postgresql_env = _env_by_name(postgresql_container)
     assert postgresql_env["POSTGRES_DB"]["value"] == "rag"
-    assert postgresql_env["POSTGRES_USER"]["valueFrom"]["secretKeyRef"]["name"] == "rag-db-credentials"
-    assert postgresql_env["POSTGRES_PASSWORD"]["valueFrom"]["secretKeyRef"]["name"] == "rag-db-credentials"
+    assert (
+        postgresql_env["POSTGRES_USER"]["valueFrom"]["secretKeyRef"]["name"] == "rag-db-credentials"
+    )
+    assert (
+        postgresql_env["POSTGRES_PASSWORD"]["valueFrom"]["secretKeyRef"]["name"]
+        == "rag-db-credentials"
+    )
 
     api = _find_by_kind_name(docs, "Deployment", "rag-rag-api")
     api_container = _container(api, "api-service")
     api_env = _env_by_name(api_container)
     assert (
         api_env["POSTGRES_URL"]["value"]
-        == "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@rag-rag-postgresql:5432/rag"
+        == "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)"
+        "@rag-rag-postgresql:5432/rag"
     )
     assert api_env["RAG_API_KEY"]["valueFrom"]["secretKeyRef"]["name"] == "rag-api-credentials"
     assert api_env["LLM_API_KEY"]["valueFrom"]["secretKeyRef"]["name"] == "rag-llm-credentials"
     assert api_env["LLM_PROVIDER"]["value"] == "google_genai"
-    assert api_env["LLM_ENDPOINT_URL"]["value"] == "https://generativelanguage.googleapis.com/v1beta"
+    assert (
+        api_env["LLM_ENDPOINT_URL"]["value"] == "https://generativelanguage.googleapis.com/v1beta"
+    )
     assert api_env["LLM_MODEL"]["value"] == "gemini-3.1-flash-lite"
     assert api_env["WATCH_ROOTS"]["value"] == "/data/watch"
     assert api_env["DOCUMENT_STORE_PATH"]["value"] == "/data/documents"

--- a/tests/smoke/test_helm_chart.py
+++ b/tests/smoke/test_helm_chart.py
@@ -32,6 +32,7 @@ def test_cluster_home_arpa_values_render_homelab_contract() -> None:
     pvc_names = {doc["metadata"]["name"] for doc in _find_kind(docs, "PersistentVolumeClaim")}
     assert "rag-rag-shared-storage" in pvc_names
     assert "rag-rag-qdrant-data" in pvc_names
+    assert "rag-rag-postgresql-data" in pvc_names
 
     shared_pvc = _find_by_kind_name(docs, "PersistentVolumeClaim", "rag-rag-shared-storage")
     assert shared_pvc["spec"]["accessModes"] == ["ReadWriteMany"]
@@ -40,11 +41,28 @@ def test_cluster_home_arpa_values_render_homelab_contract() -> None:
     qdrant_pvc = _find_by_kind_name(docs, "PersistentVolumeClaim", "rag-rag-qdrant-data")
     assert qdrant_pvc["spec"]["storageClassName"] == "longhorn-r2"
 
+    postgresql_pvc = _find_by_kind_name(docs, "PersistentVolumeClaim", "rag-rag-postgresql-data")
+    assert postgresql_pvc["spec"]["storageClassName"] == "longhorn-r2"
+
+    postgresql = _find_by_kind_name(docs, "StatefulSet", "rag-rag-postgresql")
+    postgresql_container = _container(postgresql, "postgresql")
+    postgresql_env = _env_by_name(postgresql_container)
+    assert postgresql_env["POSTGRES_DB"]["value"] == "rag"
+    assert postgresql_env["POSTGRES_USER"]["valueFrom"]["secretKeyRef"]["name"] == "rag-db-credentials"
+    assert postgresql_env["POSTGRES_PASSWORD"]["valueFrom"]["secretKeyRef"]["name"] == "rag-db-credentials"
+
     api = _find_by_kind_name(docs, "Deployment", "rag-rag-api")
     api_container = _container(api, "api-service")
     api_env = _env_by_name(api_container)
+    assert (
+        api_env["POSTGRES_URL"]["value"]
+        == "postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@rag-rag-postgresql:5432/rag"
+    )
     assert api_env["RAG_API_KEY"]["valueFrom"]["secretKeyRef"]["name"] == "rag-api-credentials"
     assert api_env["LLM_API_KEY"]["valueFrom"]["secretKeyRef"]["name"] == "rag-llm-credentials"
+    assert api_env["LLM_PROVIDER"]["value"] == "google_genai"
+    assert api_env["LLM_ENDPOINT_URL"]["value"] == "https://generativelanguage.googleapis.com/v1beta"
+    assert api_env["LLM_MODEL"]["value"] == "gemini-3.1-flash-lite"
     assert api_env["WATCH_ROOTS"]["value"] == "/data/watch"
     assert api_env["DOCUMENT_STORE_PATH"]["value"] == "/data/documents"
     assert _volume_mounts_by_name(api_container)["shared-storage"]["mountPath"] == "/data"
@@ -58,6 +76,8 @@ def test_cluster_home_arpa_values_render_homelab_contract() -> None:
 
     embedding = _find_by_kind_name(docs, "Deployment", "rag-rag-embedding-service")
     embedding_env = _env_by_name(_container(embedding, "embedding-service"))
+    assert embedding_env["EMBEDDING_BACKEND"]["value"] == "google"
+    assert embedding_env["EMBEDDING_MODEL_NAME"]["value"] == "gemini-embedding-2"
     assert (
         embedding_env["EMBEDDING_API_KEY"]["valueFrom"]["secretKeyRef"]["name"]
         == "rag-embedding-credentials"


### PR DESCRIPTION
### **User description**
## Summary

- Add an opt-in chart-owned PostgreSQL StatefulSet, Service, and PVC path while preserving external database mode.
- Move database credential selection to `database.existingSecret` so it is distinct from API/provider secret references.
- Update the homelab Helm example to use chart-owned PostgreSQL and Google Gemini/Gemini embedding endpoints instead of Ollama.
- Extend chart docs and smoke tests for the release handoff contract.

## Issue Links

Refs #39.
Refs kmikol/cluster#4.
Refs kmikol/cluster#5.

## Review Feedback

- Addressed the database secret review thread by replacing top-level `existingSecret` usage with `database.existingSecret` across templates, defaults, examples, docs, and smoke assertions.
- Fixed the lint failure by running `ruff format` on `tests/smoke/test_helm_chart.py`.

## Validation

- `make lint` passed locally.
- `make test.smoke` passed locally.

Note: the second commit was created with `--no-verify` because the local pre-commit `mypy` hook invoked the Anaconda Python 3.9 interpreter where `mypy` is unavailable. The CI-equivalent `make lint` command now passes locally under the installed project dependencies.


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Introduce an opt-in chart-owned PostgreSQL StatefulSet and Service.

- Relocate database credential selection to `database.existingSecret`.

- Update homelab example to use chart-owned PostgreSQL and Google Gemini.

- Extend Helm chart documentation and smoke tests for release contract.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RAG Helm Chart"] --> B{PostgreSQL Enabled?};
  B -- "Yes" --> C["PostgreSQL StatefulSet"];
  C --> D["PostgreSQL Service"];
  B -- "No" --> E["External PostgreSQL"];
  D -- "Provides DB Host" --> F["API Service"];
  E -- "Provides DB Host" --> F;
  D -- "Provides DB Host" --> G["Ingestion Worker"];
  E -- "Provides DB Host" --> G;
  H["Homelab Example Values"] --> I["Chart-Owned PostgreSQL Config"];
  H --> J["Google Gemini LLM/Embedding Config"];
  K["Smoke Tests"] --> L["Validate PostgreSQL Deployment"];
  K --> M["Validate Google Gemini Config"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_helm_chart.py</strong><dd><code>Add smoke tests for chart-owned PostgreSQL and Google Gemini </code><br><code>configuration</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-4524380bb80c32df90accf892a097733e0ebc541da0f4faf0bef41a3291bd9f0">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update README to reflect chart-owned PostgreSQL and database secret </code><br><code>changes</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-283efe08cac8cc818cf4ff8774c4ad02cd5a1c04dc9af2b419cdbfb996c3c0ee">+18/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>homelab-helm-contract.md</strong><dd><code>Update homelab contract documentation for PostgreSQL and storage </code><br><code>changes</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-7f90e897209cab0410301964826136813c8b6896d6da506b0bca055a1e9de289">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>values.cluster-home-arpa.example.yaml</strong><dd><code>Configure homelab example with chart-owned PostgreSQL and Google </code><br><code>Gemini</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-a6531346f2778ec11daefae585e6232d0004b1cbbd2e3f7af21a8dddb169a538">+23/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>values.example.yaml</strong><dd><code>Update default example values for database secret and PostgreSQL </code><br><code>enablement</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-25f99a7d5962ea44f2496dbbf4a4c1f3c92e9ea943507de537fe1a581171894c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>values.existing-storage.example.yaml</strong><dd><code>Update existing storage example for database secret and PostgreSQL </code><br><code>enablement</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-a6ab9c4492fc318dd245aebd7d7eb443730f4af0a8e01c7face88694e303a4a2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>values.yaml</strong><dd><code>Introduce default values for chart-owned PostgreSQL and database </code><br><code>secret</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-4f58759103e525fc2493776a68027d9527dfaf19310eb728fc17285c9b66880d">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>_helpers.tpl</strong><dd><code>Add helpers for dynamic database host and secret name resolution</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-f03db42908b23b82b071f254914d7d515dac5c8d8088c5526c7913da2a552d54">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.yaml</strong><dd><code>Update API service to use new database host and secret helpers</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-da54c2e641728a5e92ba402c1be99156413c7498337d96380af011e4dba17861">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingestion-cronjob.yaml</strong><dd><code>Update ingestion cronjob to use new database host and secret helpers</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-a90f15bb22281cffcc416aa8af4fd8728ee39dfd0133eb7fa8d6b801f6407b44">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingestion-worker.yaml</strong><dd><code>Update ingestion worker to use new database host and secret helpers</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-2aa83f12a1daee01b5e27e9d341c684f3d519dcd3170631ba389f8ef946069eb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>postgresql.yaml</strong><dd><code>Add Kubernetes StatefulSet and Service for chart-owned PostgreSQL</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-4dc38e7b20622f408047530a117e3b637c27680772fa8ae018f891f7fa0f1166">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pvc.yaml</strong><dd><code>Add PersistentVolumeClaim for chart-owned PostgreSQL data</code></dd></td>
  <td><a href="https://github.com/kmikol/rag/pull/49/files#diff-4038c0e0a2632bc1e02b44cb6fdd9479946e6a6369d867c069d0f0dc659f97d3">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

